### PR TITLE
Mmap arrays

### DIFF
--- a/alphabase/io/tempmmap.py
+++ b/alphabase/io/tempmmap.py
@@ -122,6 +122,6 @@ def clear() -> str:
         "All existing temp mmapp arrays will be unusable!"
     )
     del _TEMP_DIR
-    _TEMP_DIR = tempfile.TemporaryDirectory(prefix="tempmmap_")
+    _TEMP_DIR = tempfile.TemporaryDirectory(prefix="temp_mmap_")
     TEMP_DIR_NAME = _TEMP_DIR.name
     return TEMP_DIR_NAME


### PR DESCRIPTION
Did not branch from development, hence  PR into fix_spec_idx.

This module provides temporary mmapped arrays, to work in disk rather than in RAM. With this setup, they are fully compatible with numba and can easily be investigated with any HDF viewer if so required!