### PR TITLE
Aligning spectral library  names

### DIFF
--- a/alphabase/protein/fasta.py
+++ b/alphabase/protein/fasta.py
@@ -588,7 +588,7 @@ def append_regular_modifications(df:pd.DataFrame,
     df.reset_index(drop=True, inplace=True)
     return df
 
-class FastaLib(SpecLibBase):
+class SpecLibFasta(SpecLibBase):
     """
     This is the main entry of AlphaBase when generating spectral libraries from fasta files
     It includes functionalities to:

--- a/alphabase/spectral_library/decoy.py
+++ b/alphabase/spectral_library/decoy.py
@@ -2,7 +2,7 @@ import copy
 from alphabase.spectral_library.base import SpecLibBase
 from alphabase.io.hdf import HDF_File
 
-class DecoyLib(SpecLibBase):
+class SpecLibDecoy(SpecLibBase):
     def __init__(self, 
         target_lib:SpecLibBase,
         fix_C_term = True,
@@ -138,7 +138,7 @@ class DecoyLib(SpecLibBase):
         self._fragment_mz_df = _hdf_lib.decoy.fragment_mz_df.values
         self._fragment_intensity_df = _hdf_lib.decoy.fragment_intensity_df.values
 
-class DiaNNDecoyLib(DecoyLib):
+class SpecLibDecoyDiaNN(SpecLibDecoy):
     def __init__(self, 
         target_lib:SpecLibBase,
         raw_AAs:str = 'GAVLIFMPWSCTYHKRQENDBJOUXZ',
@@ -175,18 +175,18 @@ class DiaNNDecoyLib(DecoyLib):
                 x[2:-2]+self.mutated_AAs[self.raw_AAs.index(x[-2])]+x[-1]
         )
 
-class DecoyLibProvider(object):
+class SpecLibDecoyProvider(object):
     def __init__(self):
         self.decoy_dict = {}
 
-    def register(self, name:str, decoy_class:DecoyLib):
+    def register(self, name:str, decoy_class:SpecLibDecoy):
         """Register a new decoy class"""
         self.decoy_dict[name.lower()] = decoy_class
 
     def get_decoy_lib(self, name:str, 
         target_lib:SpecLibBase, **kwargs
-    )->DecoyLib:
-        """Get an object of a subclass of `DecoyLib` based on 
+    )->SpecLibDecoy:
+        """Get an object of a subclass of `SpecLibDecoy` based on 
         registered name.
 
         Parameters
@@ -199,7 +199,7 @@ class DecoyLibProvider(object):
 
         Returns
         -------
-        DecoyLib
+        SpecLibDecoy
             Decoy library object
         """
         if name is None: return None
@@ -211,6 +211,6 @@ class DecoyLibProvider(object):
         else:
             return None
 
-decoy_lib_provider = DecoyLibProvider()
-decoy_lib_provider.register('pseudo_reverse', DecoyLib)
-decoy_lib_provider.register('diann', DiaNNDecoyLib)
+decoy_lib_provider = SpecLibDecoyProvider()
+decoy_lib_provider.register('pseudo_reverse', SpecLibDecoy)
+decoy_lib_provider.register('diann', SpecLibDecoyDiaNN)

--- a/alphabase/spectral_library/flat.py
+++ b/alphabase/spectral_library/flat.py
@@ -11,7 +11,7 @@ from alphabase.io.hdf import HDF_File
 
 import alphabase.peptide.precursor as precursor
 
-class FlatSpecLib:
+class SpecLibFlat:
     """ 
     Flatten the spectral library (SpecLibBase) by using :meth:`parse_base_library`.
 

--- a/nbdev_nbs/protein/fasta.ipynb
+++ b/nbdev_nbs/protein/fasta.ipynb
@@ -766,7 +766,7 @@
     }
    ],
    "source": [
-    "_lib = FastaLib(None, I_to_L=False, decoy='pseudo_reverse')\n",
+    "_lib = SpecLibFasta(None, I_to_L=False, decoy='pseudo_reverse')\n",
     "prot1 = 'MABCDESTKAFGHIJKLMNOPQRAFGHIJK'\n",
     "prot2 = 'AFGHIJKLMNOPQR'\n",
     "protein_dict = {\n",
@@ -2656,7 +2656,7 @@
     }
    ],
    "source": [
-    "_lib = FastaLib(\n",
+    "_lib = SpecLibFasta(\n",
     "    ['b_z1','y_z1'], I_to_L=False, \n",
     "    decoy='pseudo_reverse',\n",
     "    precursor_mz_min=200,\n",
@@ -3097,7 +3097,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.3 ('base')",
+   "display_name": "alpha",
    "language": "python",
    "name": "python3"
   }

--- a/nbdev_nbs/protein/test_fasta.ipynb
+++ b/nbdev_nbs/protein/test_fasta.ipynb
@@ -37,7 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from alphabase.protein.fasta import FastaLib\n",
+    "from alphabase.protein.fasta import SpecLibFasta\n",
     "\n",
     "protein_dict = {\n",
     "    'xx': {\n",
@@ -50,7 +50,7 @@
     "    }\n",
     "}\n",
     "\n",
-    "fastalib = FastaLib(\n",
+    "fastalib = SpecLibFasta(\n",
     "    ['b_z1','b_z2','y_z1','y_z2'], \n",
     "    var_mods=['Oxidation@M','Acetyl@Protein N-term'],\n",
     "    fix_mods=['Carbamidomethyl@C'],\n",
@@ -202,18 +202,11 @@
     "fastalib.load_df(hdf_file_path, load_mod_seq=True)\n",
     "```"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.3 ('base')",
+   "display_name": "alpha",
    "language": "python",
    "name": "python3"
   }

--- a/nbdev_nbs/spectral_library/decoy_library.ipynb
+++ b/nbdev_nbs/spectral_library/decoy_library.ipynb
@@ -45,22 +45,18 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/MannLabs/alphabase/blob/main/alphabase/spectral_library/decoy_library.py#L53){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "### SpecLibDecoy.decoy_sequence\n",
        "\n",
-       "### DecoyLib.decoy_sequence\n",
-       "\n",
-       ">      DecoyLib.decoy_sequence ()\n",
+       ">      SpecLibDecoy.decoy_sequence ()\n",
        "\n",
        "Generate decoy sequences from `self.target_lib`"
       ],
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/MannLabs/alphabase/blob/main/alphabase/spectral_library/decoy_library.py#L53){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "### SpecLibDecoy.decoy_sequence\n",
        "\n",
-       "### DecoyLib.decoy_sequence\n",
-       "\n",
-       ">      DecoyLib.decoy_sequence ()\n",
+       ">      SpecLibDecoy.decoy_sequence ()\n",
        "\n",
        "Generate decoy sequences from `self.target_lib`"
       ]
@@ -71,7 +67,7 @@
     }
    ],
    "source": [
-    "show_doc(DecoyLib.decoy_sequence)"
+    "show_doc(SpecLibDecoy.decoy_sequence)"
    ]
   },
   {
@@ -95,15 +91,13 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/MannLabs/alphabase/blob/main/alphabase/spectral_library/decoy_library.py#L191){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "### SpecLibDecoyProvider.get_decoy_lib\n",
        "\n",
-       "### DecoyLibProvider.get_decoy_lib\n",
+       ">      SpecLibDecoyProvider.get_decoy_lib (name:str,\n",
+       ">                                          target_lib:alphabase.spectral_library\n",
+       ">                                          .base.SpecLibBase, **kwargs)\n",
        "\n",
-       ">      DecoyLibProvider.get_decoy_lib (name:str,\n",
-       ">                                      target_lib:alphabase.spectral_library.lib\n",
-       ">                                      rary_base.SpecLibBase, **kwargs)\n",
-       "\n",
-       "Get an object of a subclass of `DecoyLib` based on \n",
+       "Get an object of a subclass of `SpecLibDecoy` based on \n",
        "registered name.\n",
        "\n",
        "|    | **Type** | **Details** |\n",
@@ -111,20 +105,18 @@
        "| name | str | Registered decoy class name |\n",
        "| target_lib | SpecLibBase | Target library for decoy generation |\n",
        "| kwargs |  |  |\n",
-       "| **Returns** | **DecoyLib** | **Decoy library object** |"
+       "| **Returns** | **SpecLibDecoy** | **Decoy library object** |"
       ],
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/MannLabs/alphabase/blob/main/alphabase/spectral_library/decoy_library.py#L191){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "### SpecLibDecoyProvider.get_decoy_lib\n",
        "\n",
-       "### DecoyLibProvider.get_decoy_lib\n",
+       ">      SpecLibDecoyProvider.get_decoy_lib (name:str,\n",
+       ">                                          target_lib:alphabase.spectral_library\n",
+       ">                                          .base.SpecLibBase, **kwargs)\n",
        "\n",
-       ">      DecoyLibProvider.get_decoy_lib (name:str,\n",
-       ">                                      target_lib:alphabase.spectral_library.lib\n",
-       ">                                      rary_base.SpecLibBase, **kwargs)\n",
-       "\n",
-       "Get an object of a subclass of `DecoyLib` based on \n",
+       "Get an object of a subclass of `SpecLibDecoy` based on \n",
        "registered name.\n",
        "\n",
        "|    | **Type** | **Details** |\n",
@@ -132,7 +124,7 @@
        "| name | str | Registered decoy class name |\n",
        "| target_lib | SpecLibBase | Target library for decoy generation |\n",
        "| kwargs |  |  |\n",
-       "| **Returns** | **DecoyLib** | **Decoy library object** |"
+       "| **Returns** | **SpecLibDecoy** | **Decoy library object** |"
       ]
      },
      "execution_count": null,
@@ -141,7 +133,7 @@
     }
    ],
    "source": [
-    "show_doc(DecoyLibProvider.get_decoy_lib)"
+    "show_doc(SpecLibDecoyProvider.get_decoy_lib)"
    ]
   },
   {
@@ -159,7 +151,8 @@
     {
      "data": {
       "text/plain": [
-       "{'pseudo_reverse': __main__.DecoyLib, 'diann': __main__.DiaNNDecoyLib}"
+       "{'pseudo_reverse': alphabase.spectral_library.decoy.SpecLibDecoy,\n",
+       " 'diann': alphabase.spectral_library.decoy.SpecLibDecoyDiaNN}"
       ]
      },
      "execution_count": null,
@@ -521,7 +514,7 @@
    "outputs": [],
    "source": [
     "#| hide\n",
-    "test_lib = DecoyLib(target_lib)\n",
+    "test_lib = SpecLibDecoy(target_lib)\n",
     "test_lib.load_hdf('sandbox/decoy_lib.hdf')\n",
     "assert len(test_lib._precursor_df) > 0"
    ]
@@ -549,7 +542,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.3 ('base')",
+   "display_name": "alpha",
    "language": "python",
    "name": "python3"
   }

--- a/nbdev_nbs/spectral_library/flat_library.ipynb
+++ b/nbdev_nbs/spectral_library/flat_library.ipynb
@@ -38,36 +38,38 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/MannLabs/alphabase/blob/main/alphabase/spectral_library/flat_library.py#L101){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "### SpecLibFlat.parse_base_library\n",
        "\n",
-       "### FlatSpecLib.parse_base_library\n",
+       ">      SpecLibFlat.parse_base_library\n",
+       ">                                      (library:alphabase.spectral_library.base.\n",
+       ">                                      SpecLibBase)\n",
        "\n",
-       ">      FlatSpecLib.parse_base_library\n",
-       ">                                      (library:alphabase.spectral_library.libra\n",
-       ">                                      ry_base.SpecLibBase)\n",
-       "\n",
-       "Flatten a SpecLibBase object\n",
+       "Flatten an library object of SpecLibBase or its inherited class. \n",
+       "This method will generate :attr:`precursor_df` and :attr:`fragment_df`\n",
+       "The fragments in fragment_df can be located by \n",
+       "`frag_start_idx` and `frag_end_idx` in precursor_df.\n",
        "\n",
        "|    | **Type** | **Details** |\n",
        "| -- | -------- | ----------- |\n",
-       "| library | SpecLibBase | the library with fragment_mz_df and fragment_intensity_df |"
+       "| library | SpecLibBase | A library object with attributes<br>`precursor_df`, `fragment_mz_df` and `fragment_intensity_df`. |"
       ],
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/MannLabs/alphabase/blob/main/alphabase/spectral_library/flat_library.py#L101){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "### SpecLibFlat.parse_base_library\n",
        "\n",
-       "### FlatSpecLib.parse_base_library\n",
+       ">      SpecLibFlat.parse_base_library\n",
+       ">                                      (library:alphabase.spectral_library.base.\n",
+       ">                                      SpecLibBase)\n",
        "\n",
-       ">      FlatSpecLib.parse_base_library\n",
-       ">                                      (library:alphabase.spectral_library.libra\n",
-       ">                                      ry_base.SpecLibBase)\n",
-       "\n",
-       "Flatten a SpecLibBase object\n",
+       "Flatten an library object of SpecLibBase or its inherited class. \n",
+       "This method will generate :attr:`precursor_df` and :attr:`fragment_df`\n",
+       "The fragments in fragment_df can be located by \n",
+       "`frag_start_idx` and `frag_end_idx` in precursor_df.\n",
        "\n",
        "|    | **Type** | **Details** |\n",
        "| -- | -------- | ----------- |\n",
-       "| library | SpecLibBase | the library with fragment_mz_df and fragment_intensity_df |"
+       "| library | SpecLibBase | A library object with attributes<br>`precursor_df`, `fragment_mz_df` and `fragment_intensity_df`. |"
       ]
      },
      "execution_count": null,
@@ -76,7 +78,7 @@
     }
    ],
    "source": [
-    "show_doc(FlatSpecLib.parse_base_library)"
+    "show_doc(SpecLibFlat.parse_base_library)"
    ]
   },
   {
@@ -89,26 +91,23 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/MannLabs/alphabase/blob/main/alphabase/spectral_library/flat_library.py#L118){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "### SpecLibFlat.save_hdf\n",
        "\n",
-       "### FlatSpecLib.save_hdf\n",
-       "\n",
-       ">      FlatSpecLib.save_hdf (hdf_file:str)\n",
+       ">      SpecLibFlat.save_hdf (hdf_file:str)\n",
        "\n",
        "Save library dataframes into hdf_file.\n",
        "For `self.precursor_df`, this method will save it into two hdf groups:\n",
-       "    hdf_file: `flat_library/precursor_df` and `library/mod_seq_df`.\n",
+       "hdf_file: `flat_library/precursor_df` and `flat_library/mod_seq_df`.\n",
        "\n",
        "`flat_library/precursor_df` contains all essential numberic columns those \n",
        "can be loaded faster from hdf file into memory:\n",
-       "    'precursor_mz', 'charge', 'mod_seq_hash', 'mod_seq_charge_hash',\n",
-       "    'frag_start_idx', 'frag_end_idx', 'decoy', 'rt_pred', 'ccs_pred',\n",
-       "    'mobility_pred', 'miss_cleave', 'nAA', \n",
-       "    ['isotope_mz_m1', 'isotope_intensity_m1'], ...\n",
+       "`['precursor_mz', 'charge', 'mod_seq_hash', 'mod_seq_charge_hash',\n",
+       "'frag_start_idx', 'frag_end_idx', 'decoy', 'rt_pred', 'ccs_pred',\n",
+       "'mobility_pred', 'miss_cleave', 'nAA', 'isotope_mz_m1', 'isotope_intensity_m1', ...]`\n",
        "\n",
        "`flat_library/mod_seq_df` contains all string columns and the other \n",
        "not essential columns:\n",
-       "    'sequence','mods','mod_sites', ['proteins', 'genes']...\n",
+       "'sequence','mods','mod_sites', ['proteins', 'genes']...\n",
        "as well as 'mod_seq_hash', 'mod_seq_charge_hash' columns to map \n",
        "back to `precursor_df`\n",
        "\n",
@@ -119,26 +118,23 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/MannLabs/alphabase/blob/main/alphabase/spectral_library/flat_library.py#L118){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "### SpecLibFlat.save_hdf\n",
        "\n",
-       "### FlatSpecLib.save_hdf\n",
-       "\n",
-       ">      FlatSpecLib.save_hdf (hdf_file:str)\n",
+       ">      SpecLibFlat.save_hdf (hdf_file:str)\n",
        "\n",
        "Save library dataframes into hdf_file.\n",
        "For `self.precursor_df`, this method will save it into two hdf groups:\n",
-       "    hdf_file: `flat_library/precursor_df` and `library/mod_seq_df`.\n",
+       "hdf_file: `flat_library/precursor_df` and `flat_library/mod_seq_df`.\n",
        "\n",
        "`flat_library/precursor_df` contains all essential numberic columns those \n",
        "can be loaded faster from hdf file into memory:\n",
-       "    'precursor_mz', 'charge', 'mod_seq_hash', 'mod_seq_charge_hash',\n",
-       "    'frag_start_idx', 'frag_end_idx', 'decoy', 'rt_pred', 'ccs_pred',\n",
-       "    'mobility_pred', 'miss_cleave', 'nAA', \n",
-       "    ['isotope_mz_m1', 'isotope_intensity_m1'], ...\n",
+       "`['precursor_mz', 'charge', 'mod_seq_hash', 'mod_seq_charge_hash',\n",
+       "'frag_start_idx', 'frag_end_idx', 'decoy', 'rt_pred', 'ccs_pred',\n",
+       "'mobility_pred', 'miss_cleave', 'nAA', 'isotope_mz_m1', 'isotope_intensity_m1', ...]`\n",
        "\n",
        "`flat_library/mod_seq_df` contains all string columns and the other \n",
        "not essential columns:\n",
-       "    'sequence','mods','mod_sites', ['proteins', 'genes']...\n",
+       "'sequence','mods','mod_sites', ['proteins', 'genes']...\n",
        "as well as 'mod_seq_hash', 'mod_seq_charge_hash' columns to map \n",
        "back to `precursor_df`\n",
        "\n",
@@ -153,7 +149,7 @@
     }
    ],
    "source": [
-    "show_doc(FlatSpecLib.save_hdf)"
+    "show_doc(SpecLibFlat.save_hdf)"
    ]
   },
   {
@@ -166,11 +162,9 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/MannLabs/alphabase/blob/main/alphabase/spectral_library/flat_library.py#L171){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "### SpecLibFlat.load_hdf\n",
        "\n",
-       "### FlatSpecLib.load_hdf\n",
-       "\n",
-       ">      FlatSpecLib.load_hdf (hdf_file:str, load_mod_seq:bool=False)\n",
+       ">      SpecLibFlat.load_hdf (hdf_file:str, load_mod_seq:bool=False)\n",
        "\n",
        "Load the hdf library from hdf_file\n",
        "\n",
@@ -182,11 +176,9 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/MannLabs/alphabase/blob/main/alphabase/spectral_library/flat_library.py#L171){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "### SpecLibFlat.load_hdf\n",
        "\n",
-       "### FlatSpecLib.load_hdf\n",
-       "\n",
-       ">      FlatSpecLib.load_hdf (hdf_file:str, load_mod_seq:bool=False)\n",
+       ">      SpecLibFlat.load_hdf (hdf_file:str, load_mod_seq:bool=False)\n",
        "\n",
        "Load the hdf library from hdf_file\n",
        "\n",
@@ -202,7 +194,7 @@
     }
    ],
    "source": [
-    "show_doc(FlatSpecLib.load_hdf)"
+    "show_doc(SpecLibFlat.load_hdf)"
    ]
   },
   {
@@ -602,7 +594,7 @@
     "\n",
     "reader = SWATHLibraryReader()\n",
     "reader.import_file(StringIO(tsv_str))\n",
-    "flat_lib = FlatSpecLib(custom_fragment_df_columns=['type'])\n",
+    "flat_lib = SpecLibFlat(custom_fragment_df_columns=['type'])\n",
     "flat_lib.parse_base_library(reader)\n",
     "flat_lib.fragment_df"
    ]
@@ -769,18 +761,11 @@
     "#| hide\n",
     "flat_lib.precursor_df"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.3 ('base')",
+   "display_name": "alpha",
    "language": "python",
    "name": "python3"
   }


### PR DESCRIPTION
The spectral library names have been simplified with introducing the sphinx documentation.
As a next step, the library class names are likewise updated and aligned.

**Old spectral library naming:**
```
protein
   fasta
       FastaLib
spectral_library
   decoy_library
      DecoyLib
      DIANNDecoyLib
   flat_library
      FlatSpecLib
   library_base
      SpecLibBase
```
**New spectral library  naming:**
```
protein
   fasta
       SpecLibFasta
spectral_library
   decoy
      SpecLibDecoy
      SpecLibDecoyDIANN
   flat
      SpecLibFlat
   base
      SpecLibBase
```