### PR TITLE
fix for N-term mods

### DIFF
--- a/alphabase/psm_reader/msfragger_reader.py
+++ b/alphabase/psm_reader/msfragger_reader.py
@@ -33,13 +33,16 @@ def _get_msf_mods(sequence, msf_aa_mods):
     for mod in msf_aa_mods:
         mod_mass, site_str = mod.split('@')
         mod_mass = float(mod_mass)
-        site = int(site_str)-1
-        mod_mass = mod_mass - AA_ASCII_MASS[ord(sequence[site])]
+        site = max(0, int(site_str) - 1) #previously, site would become -1 for n-term mods, resulting in using last AA in sequence
+        if site_str == "0":
+            mod_mass -= 1.007276467 #proton. N-term variable mod is reported as mod mass + proton mass, not AA mass + mod mass
+        else:
+            mod_mass = mod_mass - AA_ASCII_MASS[ord(sequence[site])]
 
         mod_considered = False
         for mod_name in mass_mapped_mods:
             if abs(mod_mass-mod_info[mod_name]['mass'])<mod_mass_tol:
-                if site == 0 and mod_name.endswith('N-term'):
+                if site_str == "0" and mod_name.endswith('N-term'): #if site == 0, mods on first AA are considered, but they are never N-term
                     mods.append(mod_name)
                     mod_sites.append('0')
                     mod_considered = True


### PR DESCRIPTION
Hello,

Thanks for the great Alphapeptdeep tool. I was testing reading in PSMs from MSFragger pepxml files and noticed the b-ion masses were not calculated correctly. Previously, the peptide `[n-term acetylation]MD[ADP-ribosyl]LSGVK` had `b_masses` from `alphabase.peptide.fragment.calc_fragment_mz_values_for_same_nAA()` reported as 
`[45.96352207  702.05152207  815.13558605  902.16761446  959.18907818 1058.25749209]`. In addition, it was assigning the n-terminal acetylation to `mod_deltas` instead of `mods`. With the proposed changes, n-terminal modified peptides now have correct b-ion masses 
`[173.05104977  829.13904977  942.22311375 1029.25514216 1086.27660588 1185.34501979]`.
I have not tested this with C-terminal mods.

Thanks,
Kevin