### PR TITLE
msfragger pepxml reader support for c-term modifications

### DIFF
--- a/alphabase/constants/const_files/psm_reader.yaml
+++ b/alphabase/constants/const_files/psm_reader.yaml
@@ -117,6 +117,7 @@ msfragger_pepxml:
     - 'Glu->pyro-Glu@E^Any N-term'
     - 'Gln->pyro-Glu@Q^Any N-term'
     - 'Dimethyl@K' # Any N-term is not needed here as it will be infered in-the-fly
+    - 'Methyl@E' #an example of a PTM that can be C-term
   mod_mass_tol: 0.1 # Da
 diann:
   reader_type: diann

--- a/alphabase/psm_reader/msfragger_reader.py
+++ b/alphabase/psm_reader/msfragger_reader.py
@@ -6,7 +6,7 @@ from alphabase.psm_reader.psm_reader import (
     psm_reader_provider
 )
 from alphabase.constants.aa import AA_ASCII_MASS
-from alphabase.constants.atom import MASS_H
+from alphabase.constants.atom import MASS_H, MASS_O, MASS_PROTON
 from alphabase.constants.modification import MOD_MASS
 
 try:
@@ -32,8 +32,12 @@ def _get_mods_from_masses(sequence, msf_aa_mods):
         _mass_str, site_str = mod.split('@')
         mod_mass = float(_mass_str)
         site = int(site_str)
+        cterm_position = len(sequence) + 1
         if site > 0:
-            mod_mass = mod_mass - AA_ASCII_MASS[ord(sequence[site-1])]
+            if site < cterm_position:
+                mod_mass = mod_mass - AA_ASCII_MASS[ord(sequence[site-1])]
+            else:
+                mod_mass -= (MASS_H + MASS_O + MASS_PROTON)
         else:
             mod_mass -= MASS_H
 
@@ -48,6 +52,12 @@ def _get_mods_from_masses(sequence, msf_aa_mods):
                         site_str = '0'
                     else:
                         _mod = mod_name.split('@')[0]+'@'+sequence[0]
+                elif site==cterm_position:
+                    if mod_name.endswith('C-term'):
+                        _mod = mod_name
+                    else:
+                        _mod = mod_name.split('@')[0]+'@Any C-term' #what if only Protein C-term is listed?
+                    site_str = '-1'
                 else:
                     _mod = mod_name.split('@')[0]+'@'+sequence[site-1]
                 if _mod in MOD_MASS:


### PR DESCRIPTION
Thanks for waiting for these changes. I added 'Methyl@E' to psm_reader.yaml to test that fragment m/z calculations are correct for c-term mods. It can be deleted, but I am wondering why only a handful of PTMs are added, rather than putting all the entries in modification.tsv into it?

Tested using pepxml files generated from msfragger search of data from PXD014879, including c-terminal methyl as a variable mod. Ran code below from Python terminal in PyCharm IDE to ensure it works:

`from alphabase.psm_reader import *`
`from alphabase.peptide import *`

`psm_reader = psm_reader_provider.get_reader("msfragger_pepxml")`
`msf_df = psm_reader.import_file("20190131_QExHFX3_Ogris_MFPL_gel_PP2A_EV_90p.pepXML")`
`methyl_df = msf_df[msf_df['mods'].str.contains('Methyl')].copy()`
`fragment.create_fragment_mz_dataframe_by_sort_precursor(methyl_df, ['b_z1', 'y_z1', 'b_z2', 'y_z2', 'b_modloss_z1', 'y_modloss_z1', 'b_modloss_z2', 'y_modloss_z2'])`