### PR TITLE
add possibility to redefine path where tempmmap arrays are saved

### DIFF
--- a/alphabase/io/tempmmap.py
+++ b/alphabase/io/tempmmap.py
@@ -11,7 +11,7 @@ import numpy as np
 import mmap
 import h5py
 import tempfile
-
+import shutil
 
 _TEMP_DIR = tempfile.TemporaryDirectory(prefix="temp_mmap_")
 TEMP_DIR_NAME = _TEMP_DIR.name
@@ -22,6 +22,33 @@ logging.warning(
     "and might need to be triggered manually!"
 )
 
+def redefine_temp_location(path):
+    """
+    Redfine the location where the temp arrays are written to.
+
+    Parameters
+    ----------
+    path : string
+
+    Returns
+    ------
+    str
+        the location of the new temporary directory.
+
+    """
+
+    global _TEMP_DIR, _TEMP_DIR, TEMP_DIR_NAME
+    logging.warning(f'''Folder {TEMP_DIR_NAME} with temp mmap arrays is being deleted.All existing temp mmapp arrays will be unusable!''')
+    
+    #cleaup old temporary directory
+    shutil.rmtree(TEMP_DIR_NAME, ignore_errors = True)
+    del _TEMP_DIR
+
+    #create new tempfile at desired location
+    _TEMP_DIR = tempfile.TemporaryDirectory(prefix = os.path.join(path, 'temp_mmap'))
+    TEMP_DIR_NAME = _TEMP_DIR.name
+    logging.warning(f'''New temp folder location. Temp mmap arrays are written to {TEMP_DIR_NAME}. Cleanup of this folder is OS dependant, and might need to be triggered manually!''')
+    return TEMP_DIR_NAME
 
 def array(shape: tuple, dtype: np.dtype) -> np.ndarray:
     """Create a writable temporary mmapped array.


### PR DESCRIPTION
Currently there is no possibility to change the path of where memory mapped numpy arrays are written. I added a function to do this so that e.g. when you are deploying the io module on a cluster infrastructure you can define a path to large file storage system to use as a temp directory that is independent of where the code is being executed. 