### PR TITLE
resolve unexpected behaviour

### DIFF
--- a/alphabase/peptide/precursor.py
+++ b/alphabase/peptide/precursor.py
@@ -21,7 +21,7 @@ from alphabase.peptide.mass_calc import (
 
 def refine_precursor_df(
     df:pd.DataFrame, 
-    drop_frag_idx = True,
+    drop_frag_idx = False,
     ensure_data_validity = False,
 )->pd.DataFrame:
     """ 

--- a/alphabase/spectral_library/base.py
+++ b/alphabase/spectral_library/base.py
@@ -314,7 +314,6 @@ class SpecLibBase(object):
         and clip the self._precursor_df using `self.clip_by_precursor_mz_`
         """
         fragment.update_precursor_mz(self._precursor_df)
-        self.clip_by_precursor_mz_()
 
     def update_precursor_mz(self):
         """


### PR DESCRIPTION
Addresses #92 
The default behaviour of `refine_precursor_df` to drop the frag index is unexpected and annoying as decoys for example will miss the fragment idx. Therefore DIANN style decoys can't be created.

Likewise, the behaviour of `calc_precursor_mz` to clip by the precursor mz is unexpected. If someone loads a library he doesn't want any arbitrary precursor limit to be applied.
