### PR TITLE
FIX Sage reader bug

### DIFF
--- a/alphabase/psm_reader/sage_reader.py
+++ b/alphabase/psm_reader/sage_reader.py
@@ -110,6 +110,8 @@ def capture_modifications(
 
     error = False
 
+    match_delta = 0
+
     for match in matches:
         match_start, match_end = match.start(), match.end()
         previous_aa = sequence[match_start-1] if match_start > 0 else 'Any_N-term'
@@ -117,12 +119,14 @@ def capture_modifications(
 
         mod = lookup_modification(mass_observed, previous_aa, mod_annotated_df, ppm_tolerance=ppm_tolerance)
         if mod is not None:
-            site_list.append(str(match_start))
+            site_list.append(str(match_start-1-match_delta))
             mod_list.append(mod)
         
         else:
             error = True
             print(f'No modification found for mass {mass_observed} at position {match_start} with previous aa {previous_aa}')
+
+        match_delta += (match_end - match_start)
 
     if error:
         return np.nan, np.nan

--- a/nbdev_nbs/psm_reader/sage_reader.ipynb
+++ b/nbdev_nbs/psm_reader/sage_reader.ipynb
@@ -24,29 +24,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Registered reader: alphapept\n",
-      "Registered reader: maxquant\n",
-      "Registered reader: spectronaut\n",
-      "Registered reader: speclib_tsv\n",
-      "Registered reader: openswath\n",
-      "Registered reader: swath\n",
-      "Registered reader: diann\n",
-      "Registered reader: spectronaut_report\n",
-      "Registered reader: pfind\n",
-      "Registered reader: pfind3\n",
-      "Registered reader: msfragger_psm_tsv\n",
-      "Registered reader: msfragger\n",
-      "Registered reader: msfragger_pepxml\n",
-      "Registered reader: sage_tsv\n",
-      "Registered reader: sage_parquet\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from alphabase.psm_reader.sage_reader import *"
    ]
@@ -79,7 +57,7 @@
    "outputs": [],
    "source": [
     "#| hide\n",
-    "assert capture_modifications('Q[-17.026548]DQSANEKNK[+42.010567]LEM[+15.9949]NK[+42.010567]', annotated_mod_df) == ('1;22;37;49', 'Gln->pyro-Glu@Q^Any N-term;Acetyl@K;Oxidation@M;Acetyl@K')"
+    "assert capture_modifications('Q[-17.026548]DQSANEKNK[+42.010567]LEM[+15.9949]NK[+42.010567]', annotated_mod_df) == ('0;9;12;14', 'Gln->pyro-Glu@Q^Any N-term;Acetyl@K;Oxidation@M;Acetyl@K')"
    ]
   },
   {
@@ -214,7 +192,7 @@
        "      <td>0.000106</td>\n",
        "      <td>False</td>\n",
        "      <td>7932</td>\n",
-       "      <td>2</td>\n",
+       "      <td>1</td>\n",
        "      <td>Carbamidomethyl@C</td>\n",
        "      <td>15</td>\n",
        "      <td>0.770401</td>\n",
@@ -248,7 +226,7 @@
        "      <td>0.000106</td>\n",
        "      <td>False</td>\n",
        "      <td>8375</td>\n",
-       "      <td>2</td>\n",
+       "      <td>1</td>\n",
        "      <td>Oxidation@M</td>\n",
        "      <td>15</td>\n",
        "      <td>0.804350</td>\n",
@@ -301,9 +279,9 @@
        "1  sp|P25815|S100P_HUMAN  0.000106  False      4250             \n",
        "2    sp|P06748|NPM_HUMAN  0.000106  False      9584             \n",
        "3   sp|O95602|RPA1_HUMAN  0.000106  False     10841             \n",
-       "4   sp|Q9HCK8|CHD8_HUMAN  0.000106  False      7932         2   \n",
+       "4   sp|Q9HCK8|CHD8_HUMAN  0.000106  False      7932         1   \n",
        "5    sp|Q86U86|PB1_HUMAN  0.000106  False     14771             \n",
-       "6   sp|Q86TC9|MYPN_HUMAN  0.000106  False      8375         2   \n",
+       "6   sp|Q86TC9|MYPN_HUMAN  0.000106  False      8375         1   \n",
        "7  sp|O14974|MYPT1_HUMAN  0.000106  False      1864             \n",
        "\n",
        "                mods  nAA   rt_norm  precursor_mz  \n",
@@ -349,7 +327,7 @@
     "#| hide\n",
     "assert np.all(psm_df['fdr'] <= 0.01)\n",
     "assert psm_df['sequence'].iloc[4] == 'DCEDPEYKPLQGPPK'\n",
-    "assert psm_df['mod_sites'].iloc[4] == '2'\n",
+    "assert psm_df['mod_sites'].iloc[4] == '1'\n",
     "assert psm_df['mods'].iloc[4] == 'Carbamidomethyl@C'"
    ]
   }


### PR DESCRIPTION
I reported the `mod_sites` location for the modified sequence and not for the stripped sequence.