### PR TITLE
FIX match only dense dataframes

### DIFF
--- a/alphabase/spectral_library/base.py
+++ b/alphabase/spectral_library/base.py
@@ -136,7 +136,7 @@ class SpecLibBase(object):
         return self._fragment_intensity_df
     
 
-    def available_fragment_dfs(self)->list:
+    def available_dense_fragment_dfs(self)->list:
         """
         Return the available dense fragment dataframes
         By dynamically checking the attributes of the object.
@@ -198,7 +198,7 @@ class SpecLibBase(object):
             
         """
         if remove_unused_dfs:
-            current_frag_dfs = self.available_fragment_dfs()
+            current_frag_dfs = self.available_dense_fragment_dfs()
             for attr in current_frag_dfs:
                 if attr not in dfs_to_append:
                     delattr(self, attr)
@@ -501,7 +501,7 @@ class SpecLibBase(object):
         Fragment dataframes are updated inplace and overwritten.
         """
 
-        available_fragments_df = self.available_fragment_dfs()
+        available_fragments_df = self.available_dense_fragment_dfs()
         non_zero_dfs = [
             df for df in available_fragments_df 
             if len(getattr(self, df)) > 0

--- a/alphabase/spectral_library/base.py
+++ b/alphabase/spectral_library/base.py
@@ -4,6 +4,7 @@ import typing
 import logging
 import copy
 import warnings
+import re
 
 import alphabase.peptide.fragment as fragment
 import alphabase.peptide.precursor as precursor
@@ -137,7 +138,7 @@ class SpecLibBase(object):
 
     def available_fragment_dfs(self)->list:
         """
-        Return the available fragment dataframes
+        Return the available dense fragment dataframes
         By dynamically checking the attributes of the object.
         a fragment dataframe is matched with the pattern '_fragment_[attribute_name]_df'
 
@@ -148,7 +149,7 @@ class SpecLibBase(object):
         """
         return [
             attr for attr in dir(self) 
-            if attr.startswith('_fragment') and attr.endswith('_df')
+            if re.match(r'_fragment_.*_df', attr)
         ]
     
     def copy(self):

--- a/alphabase/spectral_library/flat.py
+++ b/alphabase/spectral_library/flat.py
@@ -138,7 +138,7 @@ class SpecLibFlat(SpecLibBase):
 
             self.charged_frag_types = library.fragment_mz_df.columns.values
             for dense_frag_df in library.available_dense_fragment_dfs():
-                setattr(self, dense_frag_df), getattr(library, dense_frag_df)
+                setattr(self, dense_frag_df, getattr(library, dense_frag_df))
 
             warnings.warn(
                 "The SpecLibFlat object will have a strictly flat representation in the future. keep_original_frag_dfs=True will be deprecated.",

--- a/alphabase/spectral_library/flat.py
+++ b/alphabase/spectral_library/flat.py
@@ -1,5 +1,7 @@
 import pandas as pd
 import numpy as np
+import warnings
+
 from alphabase.spectral_library.base import (
     SpecLibBase
 )
@@ -77,10 +79,22 @@ class SpecLibFlat(SpecLibBase):
     def protein_df(self)->pd.DataFrame:
         """ Protein dataframe """
         return self._protein_df
-
+    
+    def available_dense_fragment_dfs(self):
+        """Return the available dense fragment dataframes.
+        This method is inherited from :class:`SpecLibBase` and will return an empty list for a flat library.
+        """
+        return []
+    
+    def remove_unused_fragments(self):
+        """Remove unused fragments from fragment_df.
+        This method is inherited from :class:`SpecLibBase` and has not been implemented for a flat library.
+        """
+        raise NotImplementedError("remove_unused_fragments is not implemented for a flat library")
+    
     def parse_base_library(self, 
         library:SpecLibBase,
-        keep_original_frag_dfs:bool=True,
+        keep_original_frag_dfs:bool=False,
         copy_precursor_df:bool=False,
         **kwargs
     ):
@@ -121,12 +135,16 @@ class SpecLibFlat(SpecLibBase):
             self._protein_df = pd.DataFrame()
 
         if keep_original_frag_dfs:
+
             self.charged_frag_types = library.fragment_mz_df.columns.values
-            self._fragment_mz_df = library.fragment_mz_df
-            self._fragment_intensity_df = library.fragment_intensity_df
-        else:
-            self._fragment_mz_df = pd.DataFrame()
-            self._fragment_intensity_df = pd.DataFrame()
+            for dense_frag_df in library.available_dense_fragment_dfs():
+                setattr(self, dense_frag_df), getattr(library, dense_frag_df)
+
+            warnings.warn(
+                "The SpecLibFlat object will have a strictly flat representation in the future. keep_original_frag_dfs=True will be deprecated.",
+                DeprecationWarning
+            )
+
 
     def save_hdf(self, hdf_file:str):
         """Save library dataframes into hdf_file.

--- a/nbdev_nbs/spectral_library/flat_library.ipynb
+++ b/nbdev_nbs/spectral_library/flat_library.ipynb
@@ -874,7 +874,7 @@
     }
    ],
    "source": [
-    "back_to_base.available_fragment_dfs()"
+    "back_to_base.available_dense_fragment_dfs()"
    ]
   },
   {


### PR DESCRIPTION
`SpecLibBase.available_fragment_dfs()` would return `['_fragment_df', '_fragment_intensity_df', '_fragment_mz_df']` on a SpecLibFlat and fail on `.remove_unused_fragments()`.

This makes sure it's really matching `_fragment_[attribute_name]_df`.

