### PR TITLE
158 ruff linting (#158)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.3.7
+  rev: v0.4.0
   hooks:
     - id: ruff-format
+    - id: ruff

--- a/alphabase/constants/element.py
+++ b/alphabase/constants/element.py
@@ -1,1 +1,1 @@
-from .atom import *
+from .atom import *  # noqa: F403

--- a/alphabase/constants/isotope.py
+++ b/alphabase/constants/isotope.py
@@ -7,6 +7,7 @@ from alphabase.constants.element import (
     EMPTY_DIST,
     CHEM_ISOTOPE_DIST,
     CHEM_MONO_IDX,
+    CHEM_MONO_MASS,  # noqa: F401 apparently some test code depends on this being imported here TODO fix
     truncate_isotope,
     parse_formula,
 )

--- a/alphabase/constants/isotope.py
+++ b/alphabase/constants/isotope.py
@@ -7,7 +7,6 @@ from alphabase.constants.element import (
     EMPTY_DIST,
     CHEM_ISOTOPE_DIST,
     CHEM_MONO_IDX,
-    CHEM_MONO_MASS,
     truncate_isotope,
     parse_formula,
 )

--- a/alphabase/io/hdf.py
+++ b/alphabase/io/hdf.py
@@ -4,7 +4,6 @@ import pandas as pd
 import re
 import contextlib
 import time
-import warnings
 
 
 class HDF_Object(object):

--- a/alphabase/io/psm_reader/__init__.py
+++ b/alphabase/io/psm_reader/__init__.py
@@ -1,2 +1,2 @@
 # Legacy, use alphabase.psm_reader instead
-from alphabase.psm_reader import *
+from alphabase.psm_reader import *  # noqa: F403

--- a/alphabase/io/psm_reader/alphapept_reader.py
+++ b/alphabase/io/psm_reader/alphapept_reader.py
@@ -1,1 +1,1 @@
-from alphabase.psm_reader.alphapept_reader import *
+from alphabase.psm_reader.alphapept_reader import *  # noqa: F403

--- a/alphabase/io/psm_reader/dia_psm_reader.py
+++ b/alphabase/io/psm_reader/dia_psm_reader.py
@@ -1,1 +1,1 @@
-from alphabase.psm_reader.dia_psm_reader import *
+from alphabase.psm_reader.dia_psm_reader import *  # noqa: F403

--- a/alphabase/io/psm_reader/dia_search_reader.py
+++ b/alphabase/io/psm_reader/dia_search_reader.py
@@ -1,2 +1,2 @@
 # Legacy, use .dia_psm_reader instead
-from alphabase.psm_reader.dia_psm_reader import *
+from alphabase.psm_reader.dia_psm_reader import *  # noqa: F403

--- a/alphabase/io/psm_reader/maxquant_reader.py
+++ b/alphabase/io/psm_reader/maxquant_reader.py
@@ -1,1 +1,1 @@
-from alphabase.psm_reader.maxquant_reader import *
+from alphabase.psm_reader.maxquant_reader import *  # noqa: F403

--- a/alphabase/io/psm_reader/msfragger_reader.py
+++ b/alphabase/io/psm_reader/msfragger_reader.py
@@ -1,1 +1,1 @@
-from alphabase.psm_reader.msfragger_reader import *
+from alphabase.psm_reader.msfragger_reader import *  # noqa: F403

--- a/alphabase/io/psm_reader/pfind_reader.py
+++ b/alphabase/io/psm_reader/pfind_reader.py
@@ -1,1 +1,1 @@
-from alphabase.psm_reader.pfind_reader import *
+from alphabase.psm_reader.pfind_reader import *  # noqa: F403

--- a/alphabase/io/psm_reader/psm_reader.py
+++ b/alphabase/io/psm_reader/psm_reader.py
@@ -1,1 +1,1 @@
-from alphabase.psm_reader.psm_reader import *
+from alphabase.psm_reader.psm_reader import *  # noqa: F403

--- a/alphabase/peptide/fragment.py
+++ b/alphabase/peptide/fragment.py
@@ -9,8 +9,7 @@ from alphabase.constants.modification import calc_modloss_mass
 from alphabase.constants.element import (
     MASS_PROTON,
 )
-from alphabase.peptide.mass_calc import calc_b_y_and_peptide_masses_for_same_len_seqs
-
+from alphabase.peptide.mass_calc import *  # noqa: F403 apparently some test code depends on things imported here TODO fix
 from alphabase.peptide.precursor import (
     refine_precursor_df,
     is_precursor_sorted,
@@ -404,7 +403,7 @@ def calc_fragment_mz_values_for_same_nAA(
     else:
         mod_diff_list = None
         mod_diff_site_list = None
-    (b_mass, y_mass, pepmass) = calc_b_y_and_peptide_masses_for_same_len_seqs(
+    (b_mass, y_mass, pepmass) = calc_b_y_and_peptide_masses_for_same_len_seqs(  # noqa: F405 TODO remove once the import is done explicitly
         df_group.sequence.values.astype("U"),
         mod_list,
         site_list,

--- a/alphabase/peptide/fragment.py
+++ b/alphabase/peptide/fragment.py
@@ -12,6 +12,7 @@ from alphabase.constants.element import (
 from alphabase.peptide.mass_calc import *  # noqa: F403 apparently some test code depends on things imported here TODO fix
 from alphabase.peptide.precursor import (
     refine_precursor_df,
+    update_precursor_mz,  # noqa: F401 apparently some test code depends on this being imported here TODO fix
     is_precursor_sorted,
 )
 

--- a/alphabase/peptide/fragment.py
+++ b/alphabase/peptide/fragment.py
@@ -1322,7 +1322,7 @@ def calc_fragment_cardinality(
         fragment_mz,
         fragment_cardinality,
     ):
-        elution_group = elution_group_idx[0]
+        elution_group_idx[0]  # noqa TODO check for potential bug
         elution_group_start = 0
 
         for i in range(len(elution_group_idx)):

--- a/alphabase/peptide/fragment.py
+++ b/alphabase/peptide/fragment.py
@@ -1,25 +1,17 @@
 import numpy as np
 import pandas as pd
-from typing import List, Union, Tuple, Dict, TYPE_CHECKING
-import warnings
+from typing import List, Union, Tuple, Dict
 import numba as nb
-import logging
 
 from alphabase.constants._const import PEAK_MZ_DTYPE, PEAK_INTENSITY_DTYPE
 from alphabase.peptide.mass_calc import *
 from alphabase.constants.modification import calc_modloss_mass
 from alphabase.constants.element import (
-    MASS_H2O,
     MASS_PROTON,
-    MASS_NH3,
-    MASS_H,
-    MASS_C,
-    MASS_O,
 )
 
 from alphabase.peptide.precursor import (
     refine_precursor_df,
-    update_precursor_mz,
     is_precursor_sorted,
 )
 

--- a/alphabase/peptide/fragment.py
+++ b/alphabase/peptide/fragment.py
@@ -4,11 +4,12 @@ from typing import List, Union, Tuple, Dict
 import numba as nb
 
 from alphabase.constants._const import PEAK_MZ_DTYPE, PEAK_INTENSITY_DTYPE
-from alphabase.peptide.mass_calc import *
+
 from alphabase.constants.modification import calc_modloss_mass
 from alphabase.constants.element import (
     MASS_PROTON,
 )
+from alphabase.peptide.mass_calc import calc_b_y_and_peptide_masses_for_same_len_seqs
 
 from alphabase.peptide.precursor import (
     refine_precursor_df,

--- a/alphabase/protein/fasta.py
+++ b/alphabase/protein/fasta.py
@@ -1251,7 +1251,7 @@ class SpecLibFasta(SpecLibBase):
             )
             if "labeling_channel" not in self.key_numeric_columns:
                 self.key_numeric_columns.append("labeling_channel")
-        except:
+        except Exception:
             if "labeling_channel" in self.key_numeric_columns:
                 self.key_numeric_columns.remove("labeling_channel")
 

--- a/alphabase/psm_reader/__init__.py
+++ b/alphabase/psm_reader/__init__.py
@@ -18,6 +18,6 @@ from alphabase.psm_reader.msfragger_reader import MSFragger_PSM_TSV_Reader
 from alphabase.psm_reader.sage_reader import SageReaderTSV, SageReaderParquet
 
 try:
-    from alphabase.psm_reader.msfragger_reader import MSFraggerPepXML  # noqa: F401 TODO remove import side effects
+    from alphabase.psm_reader.msfragger_reader import MSFraggerPepXML  # noqa: F401 TODO remove import side effects (registering the reader)
 except ImportError:
     pass

--- a/alphabase/psm_reader/__init__.py
+++ b/alphabase/psm_reader/__init__.py
@@ -1,3 +1,4 @@
+# ruff: noqa: F401 TODO remove import side effects (i.e. change way readers are registered)
 # to register all readers into .psm_reader.psm_reader_provider
 from alphabase.psm_reader.psm_reader import (
     psm_reader_provider,
@@ -17,6 +18,6 @@ from alphabase.psm_reader.msfragger_reader import MSFragger_PSM_TSV_Reader
 from alphabase.psm_reader.sage_reader import SageReaderTSV, SageReaderParquet
 
 try:
-    from alphabase.psm_reader.msfragger_reader import MSFraggerPepXML
+    from alphabase.psm_reader.msfragger_reader import MSFraggerPepXML  # noqa: F401 TODO remove import side effects
 except ImportError:
     pass

--- a/alphabase/psm_reader/msfragger_reader.py
+++ b/alphabase/psm_reader/msfragger_reader.py
@@ -7,7 +7,7 @@ from alphabase.psm_reader.psm_reader import (
     psm_reader_provider,
 )
 from alphabase.constants.aa import AA_ASCII_MASS
-from alphabase.constants.atom import MASS_H, MASS_O, MASS_PROTON
+from alphabase.constants.atom import MASS_H, MASS_O
 from alphabase.constants.modification import MOD_MASS
 
 try:

--- a/alphabase/psm_reader/msfragger_reader.py
+++ b/alphabase/psm_reader/msfragger_reader.py
@@ -12,7 +12,7 @@ from alphabase.constants.modification import MOD_MASS
 
 try:
     import pyteomics.pepxml as pepxml
-except:
+except ImportError:
     pepxml = None
 
 

--- a/alphabase/psm_reader/psm_reader.py
+++ b/alphabase/psm_reader/psm_reader.py
@@ -70,7 +70,7 @@ def keep_modifications(mod_str: str, mod_set: set) -> str:
     if not mod_str:
         return ""
     for mod in mod_str.split(";"):
-        if not mod in mod_set:
+        if mod not in mod_set:
             return pd.NA
     return mod_str
 
@@ -339,11 +339,11 @@ class PSMReaderBase(object):
         self.normalize_rt()
 
     def normalize_rt_by_raw_name(self):
-        if not "rt" in self.psm_df.columns:
+        if "rt" not in self.psm_df.columns:
             return
-        if not "rt_norm" in self.psm_df.columns:
+        if "rt_norm" not in self.psm_df.columns:
             self.norm_rt()
-        if not "raw_name" in self.psm_df.columns:
+        if "raw_name" not in self.psm_df.columns:
             return
         for raw_name, df_group in self.psm_df.groupby("raw_name"):
             self.psm_df.loc[df_group.index, "rt_norm"] = (
@@ -407,7 +407,7 @@ class PSMReaderBase(object):
 
         if (
             "scan_num" in self._psm_df.columns
-            and not "spec_idx" in self._psm_df.columns
+            and "spec_idx" not in self._psm_df.columns
         ):
             self._psm_df["spec_idx"] = self._psm_df.scan_num - 1
 

--- a/alphabase/psm_reader/psm_reader.py
+++ b/alphabase/psm_reader/psm_reader.py
@@ -1,6 +1,5 @@
 import os
 import copy
-import io
 import pandas as pd
 import numpy as np
 import warnings

--- a/alphabase/quantification/quant_reader/config_dict_loader.py
+++ b/alphabase/quantification/quant_reader/config_dict_loader.py
@@ -102,7 +102,7 @@ def _get_quant_ids_from_config_dict(config_typedict):
     quantID = config_typedict.get("quant_ID")
     if type(quantID) == type("string"):
         return [config_typedict.get("quant_ID")]
-    if quantID == None:
+    if quantID is None:
         return []
     else:
         return list(config_typedict.get("quant_ID").values())
@@ -112,7 +112,7 @@ def _get_sample_ids_from_config_dict(config_typedict):
     sampleID = config_typedict.get("sample_ID")
     if type(sampleID) == type("string"):
         return [config_typedict.get("sample_ID")]
-    if sampleID == None:
+    if sampleID is None:
         return []
     else:
         return config_typedict.get("sample_ID")

--- a/alphabase/quantification/quant_reader/config_dict_loader.py
+++ b/alphabase/quantification/quant_reader/config_dict_loader.py
@@ -100,7 +100,7 @@ def get_relevant_columns_config_dict(config_typedict):
 
 def _get_quant_ids_from_config_dict(config_typedict):
     quantID = config_typedict.get("quant_ID")
-    if type(quantID) == type("string"):
+    if isinstance(quantID, str):
         return [config_typedict.get("quant_ID")]
     if quantID is None:
         return []
@@ -110,7 +110,7 @@ def _get_quant_ids_from_config_dict(config_typedict):
 
 def _get_sample_ids_from_config_dict(config_typedict):
     sampleID = config_typedict.get("sample_ID")
-    if type(sampleID) == type("string"):
+    if isinstance(sampleID, str):
         return [config_typedict.get("sample_ID")]
     if sampleID is None:
         return []

--- a/alphabase/quantification/quant_reader/longformat_reader.py
+++ b/alphabase/quantification/quant_reader/longformat_reader.py
@@ -4,7 +4,6 @@ import shutil
 import glob
 import dask.dataframe as dd
 import os.path
-import sys
 
 from . import config_dict_loader
 from . import quantreader_utils

--- a/alphabase/quantification/quant_reader/plexdia_reformatter.py
+++ b/alphabase/quantification/quant_reader/plexdia_reformatter.py
@@ -1,3 +1,6 @@
+import re
+
+
 def extend_sample_allcolumns_for_mDIA_case(allcols_samples, config_dict_for_type):
     if is_mDIA_table(config_dict_for_type):
         new_allcols = []
@@ -45,9 +48,6 @@ def remove_mtraq_modifications_from_ion_ids(ions):
 
 def is_mDIA_table(config_dict_for_type):
     return config_dict_for_type.get("channel_ID") == ["Channel.0", "Channel.4"]
-
-
-import re
 
 
 def parse_channel_from_peptide_column(input_df):

--- a/alphabase/quantification/quant_reader/quantreader_utils.py
+++ b/alphabase/quantification/quant_reader/quantreader_utils.py
@@ -1,5 +1,5 @@
 def filter_input(filter_dict, input):
-    if filter_dict == None:
+    if filter_dict is None:
         return input
     for filtname, filterconf in filter_dict.items():
         param = filterconf.get("param")

--- a/alphabase/quantification/quant_reader/quantreader_utils.py
+++ b/alphabase/quantification/quant_reader/quantreader_utils.py
@@ -16,7 +16,7 @@ def filter_input(filter_dict, input):
             continue
         try:
             input = input.astype({f"{param}": "float"})
-        except:
+        except Exception:
             pass
 
         if comparator == ">":

--- a/alphabase/quantification/quant_reader/table_reformatter.py
+++ b/alphabase/quantification/quant_reader/table_reformatter.py
@@ -118,7 +118,7 @@ def split_extend_df(input_df, splitcol2sep, value_threshold=10):
     Returns:
         Pandas Dataframe: Pandas dataframe with the condensed items expanded to long format
     """
-    if splitcol2sep == None:
+    if splitcol2sep is None:
         return input_df
 
     for split_col, separator in splitcol2sep.items():
@@ -178,7 +178,7 @@ def add_index_and_metadata_columns(
     )  # df_subset[ion_hierarchy_local].apply(lambda x: '_AND_'.join(x.astype(str)), axis=1)
 
     df_subset = df_subset.set_index(ion_hierarchy_local)
-    if quant_id_dict != None:
+    if quant_id_dict is not None:
         df_subset = df_subset.rename(
             columns={quant_id_dict.get(hierarchy_type): "quant_val"}
         )

--- a/alphabase/quantification/quant_reader/table_reformatter.py
+++ b/alphabase/quantification/quant_reader/table_reformatter.py
@@ -1,4 +1,3 @@
-import itertools
 import pandas as pd
 import copy
 

--- a/alphabase/quantification/quant_reader/wideformat_reader.py
+++ b/alphabase/quantification/quant_reader/wideformat_reader.py
@@ -6,8 +6,7 @@ from . import table_reformatter
 def reformat_and_write_wideformat_table(peptides_tsv, outfile_name, config_dict):
     input_df = pd.read_csv(peptides_tsv, sep="\t", encoding="latin1")
     filter_dict = config_dict.get("filters")
-    protein_cols = config_dict.get("protein_cols")
-    ion_cols = config_dict.get("ion_cols")
+
     input_df = quantreader_utils.filter_input(filter_dict, input_df)
     # input_df = merge_protein_and_ion_cols(input_df, config_dict)
     input_df = table_reformatter.merge_protein_cols_and_config_dict(

--- a/alphabase/scoring/ml_scoring.py
+++ b/alphabase/scoring/ml_scoring.py
@@ -2,7 +2,6 @@ import pandas as pd
 import numpy as np
 
 from sklearn.linear_model import LogisticRegression
-from sklearn.base import BaseEstimator
 
 from alphabase.scoring.feature_extraction_base import BaseFeatureExtractor
 from alphabase.scoring.fdr import (

--- a/alphabase/scoring/ml_scoring.py
+++ b/alphabase/scoring/ml_scoring.py
@@ -7,8 +7,6 @@ from sklearn.base import BaseEstimator
 from alphabase.scoring.feature_extraction_base import BaseFeatureExtractor
 from alphabase.scoring.fdr import (
     calculate_fdr,
-    calculate_fdr_from_ref,
-    fdr_to_q_values,
     fdr_from_ref,
 )
 

--- a/alphabase/spectral_library/base.py
+++ b/alphabase/spectral_library/base.py
@@ -309,7 +309,7 @@ class SpecLibBase(object):
         from alphabase.spectral_library.decoy import decoy_lib_provider
 
         # register 'protein_reverse' to the decoy_lib_provider
-        import alphabase.protein.protein_level_decoy  # noqa: F401 TODO this import has a side effect
+        import alphabase.protein.protein_level_decoy  # noqa: F401 TODO this import has a side effect (registering the reader)
 
         decoy_lib = decoy_lib_provider.get_decoy_lib(self.decoy, self)
         if decoy_lib is None:

--- a/alphabase/spectral_library/base.py
+++ b/alphabase/spectral_library/base.py
@@ -258,7 +258,7 @@ class SpecLibBase(object):
 
         if not np.all(np.array(n_fragments) == n_fragments[0]):
             raise ValueError(
-                f"The libraries can't be appended as the number of fragments in the current libraries are not the same."
+                "The libraries can't be appended as the number of fragments in the current libraries are not the same."
             )
 
         for attr, matching_columns in zip(dfs_to_append, matching_columns):

--- a/alphabase/spectral_library/base.py
+++ b/alphabase/spectral_library/base.py
@@ -309,7 +309,7 @@ class SpecLibBase(object):
         from alphabase.spectral_library.decoy import decoy_lib_provider
 
         # register 'protein_reverse' to the decoy_lib_provider
-        import alphabase.protein.protein_level_decoy
+        import alphabase.protein.protein_level_decoy  # noqa: F401 TODO this import has a side effect
 
         decoy_lib = decoy_lib_provider.get_decoy_lib(self.decoy, self)
         if decoy_lib is None:

--- a/alphabase/spectral_library/decoy.py
+++ b/alphabase/spectral_library/decoy.py
@@ -2,9 +2,7 @@ import copy
 from typing import Any
 import pandas as pd
 import multiprocessing as mp
-from functools import partial
 from alphabase.spectral_library.base import SpecLibBase
-from alphabase.io.hdf import HDF_File
 
 
 def _batchify_series(series, mp_batch_size):

--- a/alphabase/spectral_library/flat.py
+++ b/alphabase/spectral_library/flat.py
@@ -7,8 +7,6 @@ from alphabase.peptide.fragment import flatten_fragments, remove_unused_fragment
 
 from alphabase.io.hdf import HDF_File
 
-import alphabase.peptide.precursor as precursor
-
 
 class SpecLibFlat(SpecLibBase):
     """

--- a/alphabase/spectral_library/reader.py
+++ b/alphabase/spectral_library/reader.py
@@ -4,7 +4,7 @@ import pandas as pd
 from tqdm import tqdm
 
 from alphabase.peptide.mobility import mobility_to_ccs_for_df
-from alphabase.io.psm_reader.dia_search_reader import SpectronautReader  # noqa: F401 TODO this import has a side effect
+from alphabase.io.psm_reader.dia_search_reader import SpectronautReader  # noqa: F401 TODO this import has a side effect (registering the reader)
 from alphabase.io.psm_reader.maxquant_reader import MaxQuantReader
 from alphabase.spectral_library.base import SpecLibBase
 from alphabase.psm_reader.psm_reader import psm_reader_yaml

--- a/alphabase/spectral_library/reader.py
+++ b/alphabase/spectral_library/reader.py
@@ -1,18 +1,16 @@
 import typing
-import os
 import numpy as np
 import pandas as pd
 from tqdm import tqdm
 
 from alphabase.peptide.mobility import mobility_to_ccs_for_df
-from alphabase.io.psm_reader.dia_search_reader import SpectronautReader
+from alphabase.io.psm_reader.dia_search_reader import SpectronautReader  # noqa: F401 TODO this import has a side effect
 from alphabase.io.psm_reader.maxquant_reader import MaxQuantReader
 from alphabase.spectral_library.base import SpecLibBase
 from alphabase.psm_reader.psm_reader import psm_reader_yaml
 from alphabase.psm_reader import psm_reader_provider
 
-from alphabase.constants._const import CONST_FILE_FOLDER, PEAK_INTENSITY_DTYPE
-from alphabase.yaml_utils import load_yaml
+from alphabase.constants._const import PEAK_INTENSITY_DTYPE
 
 
 class LibraryReaderBase(MaxQuantReader, SpecLibBase):

--- a/alphabase/spectral_library/validate.py
+++ b/alphabase/spectral_library/validate.py
@@ -186,7 +186,7 @@ class Schema:
         self.schema = properties
         for column in self.schema:
             if not isinstance(column, Column):
-                raise ValueError(f"Schema must contain only Property objects")
+                raise ValueError("Schema must contain only Property objects")
 
     def __call__(self, df):
         """

--- a/alphabase/statistics/regression.py
+++ b/alphabase/statistics/regression.py
@@ -3,6 +3,7 @@ import numpy as np
 from sklearn.preprocessing import PolynomialFeatures
 from sklearn.base import BaseEstimator, RegressorMixin
 
+from sklearn.utils.estimator_checks import check_estimator  # noqa: F401 apparently some test code depends on this being imported here TODO fix
 
 EPSILON = 1e-6
 

--- a/alphabase/statistics/regression.py
+++ b/alphabase/statistics/regression.py
@@ -3,8 +3,6 @@ import numpy as np
 from sklearn.preprocessing import PolynomialFeatures
 from sklearn.base import BaseEstimator, RegressorMixin
 
-from sklearn.utils.estimator_checks import check_estimator
-
 
 EPSILON = 1e-6
 

--- a/alphabase/statistics/regression.py
+++ b/alphabase/statistics/regression.py
@@ -257,7 +257,7 @@ class LOESSRegression(BaseEstimator, RegressorMixin):
         for i, weights in enumerate(w.T):
             loadings = np.linalg.inv(x_design.T * weights @ x_design) @ x_design.T
             beta = (loadings * weights) @ y
-            y_m = np.sum(x_design @ beta, axis=1)
+            y_m = np.sum(x_design @ beta, axis=1)  # noqa TODO check for potential bug
             self.beta[:, i] = np.ravel((loadings * weights) @ y)
 
         return self

--- a/alphabase/utils.py
+++ b/alphabase/utils.py
@@ -1,6 +1,4 @@
 import tqdm
-import os
-import sys
 import pandas as pd
 import itertools
 import io

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "_modidx,py"]
 
-code_url = f"https://github.com/mannlabs/alphabase/blob/main"
+code_url = "https://github.com/mannlabs/alphabase/blob/main"
 
 
 def linkcode_resolve(domain, info):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,4 @@
 [tool.ruff.lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 select = []
-ignore = ["ALL"]
+ignore = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 
 [tool.ruff.lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
-select = ["E4", "E7", "E9", "F"]
-ignore = []
+select = []
+ignore = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+
+[tool.ruff.lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 
 [tool.ruff.lint]
-# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
-select = []
-ignore = []
+select = ["E", "F"]
+ignore = [
+    "E501"  # Line too long  (ruff wraps code, but not docstrings)
+]

--- a/release/pyinstaller/alphabase_pyinstaller.py
+++ b/release/pyinstaller/alphabase_pyinstaller.py
@@ -5,7 +5,7 @@ if __name__ == "__main__":
 
         multiprocessing.freeze_support()
         alphabase.gui.run()
-    except e:
+    except Exception:
         import traceback
         import sys
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 # builtin
 import setuptools
 import re
-import os
 
 # local
 import alphabase as package2install


### PR DESCRIPTION
The next step towards clean code :-) (added a lot of reviewers to give you a feeling for these kind of changes)
see issue #158 for high-level context

- adding ruff's lint checks to the pre-commit hook (see files `.pre-commit-config.yaml, pyproject.toml`)
- changed code to comply with the suggested "starter rules" (E, F) (see rest of files)
  - applied safe & unsafe autofixes (with caution)
  - fixed the rest of the issues manually

I chose to add `# noqa` whenever I was not 100% sure that I am not breaking something. For the "unused imports", we should discuss if this code could be removed.

Also, I think ruff found two bugs (marked with TODOs)


Just for full transparency, this was the output on the base branch:
```
>  pre-commit run --all-files
alphabase/constants/element.py:1:1: F403 `from .atom import *` used; unable to detect undefined names
alphabase/constants/isotope.py:10:5: F401 [*] `alphabase.constants.element.CHEM_MONO_MASS` imported but unused
alphabase/io/hdf.py:7:8: F401 [*] `warnings` imported but unused
alphabase/io/psm_reader/__init__.py:2:1: F403 `from alphabase.psm_reader import *` used; unable to detect undefined names
alphabase/io/psm_reader/alphapept_reader.py:1:1: F403 `from alphabase.psm_reader.alphapept_reader import *` used; unable to detect undefined names
alphabase/io/psm_reader/dia_psm_reader.py:1:1: F403 `from alphabase.psm_reader.dia_psm_reader import *` used; unable to detect undefined names
alphabase/io/psm_reader/dia_search_reader.py:2:1: F403 `from alphabase.psm_reader.dia_psm_reader import *` used; unable to detect undefined names
alphabase/io/psm_reader/maxquant_reader.py:1:1: F403 `from alphabase.psm_reader.maxquant_reader import *` used; unable to detect undefined names
alphabase/io/psm_reader/msfragger_reader.py:1:1: F403 `from alphabase.psm_reader.msfragger_reader import *` used; unable to detect undefined names
alphabase/io/psm_reader/pfind_reader.py:1:1: F403 `from alphabase.psm_reader.pfind_reader import *` used; unable to detect undefined names
alphabase/io/psm_reader/psm_reader.py:1:1: F403 `from alphabase.psm_reader.psm_reader import *` used; unable to detect undefined names
alphabase/peptide/fragment.py:3:46: F401 [*] `typing.TYPE_CHECKING` imported but unused
alphabase/peptide/fragment.py:4:8: F401 [*] `warnings` imported but unused
alphabase/peptide/fragment.py:6:8: F401 [*] `logging` imported but unused
alphabase/peptide/fragment.py:9:1: F403 `from alphabase.peptide.mass_calc import *` used; unable to detect undefined names
alphabase/peptide/fragment.py:12:5: F401 [*] `alphabase.constants.element.MASS_H2O` imported but unused
alphabase/peptide/fragment.py:14:5: F401 [*] `alphabase.constants.element.MASS_NH3` imported but unused
alphabase/peptide/fragment.py:15:5: F401 [*] `alphabase.constants.element.MASS_H` imported but unused
alphabase/peptide/fragment.py:16:5: F401 [*] `alphabase.constants.element.MASS_C` imported but unused
alphabase/peptide/fragment.py:17:5: F401 [*] `alphabase.constants.element.MASS_O` imported but unused
alphabase/peptide/fragment.py:22:5: F401 [*] `alphabase.peptide.precursor.update_precursor_mz` imported but unused
alphabase/peptide/fragment.py:414:33: F405 `calc_b_y_and_peptide_masses_for_same_len_seqs` may be undefined, or defined from star imports
alphabase/peptide/fragment.py:1333:9: F841 Local variable `elution_group` is assigned to but never used
alphabase/protein/fasta.py:1254:9: E722 Do not use bare `except`
alphabase/psm_reader/__init__.py:3:5: F401 `alphabase.psm_reader.psm_reader.psm_reader_provider` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
alphabase/psm_reader/__init__.py:4:5: F401 `alphabase.psm_reader.psm_reader.psm_reader_yaml` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
alphabase/psm_reader/__init__.py:5:5: F401 `alphabase.psm_reader.psm_reader.PSMReaderBase` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
alphabase/psm_reader/__init__.py:7:51: F401 `alphabase.psm_reader.alphapept_reader.AlphaPeptReader` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
alphabase/psm_reader/__init__.py:9:5: F401 `alphabase.psm_reader.dia_psm_reader.DiannReader` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
alphabase/psm_reader/__init__.py:10:5: F401 `alphabase.psm_reader.dia_psm_reader.SpectronautReader` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
alphabase/psm_reader/__init__.py:11:5: F401 `alphabase.psm_reader.dia_psm_reader.SwathReader` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
alphabase/psm_reader/__init__.py:12:5: F401 `alphabase.psm_reader.dia_psm_reader.SpectronautReportReader` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
alphabase/psm_reader/__init__.py:14:50: F401 `alphabase.psm_reader.maxquant_reader.MaxQuantReader` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
alphabase/psm_reader/__init__.py:15:47: F401 `alphabase.psm_reader.pfind_reader.pFindReader` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
alphabase/psm_reader/__init__.py:16:51: F401 `alphabase.psm_reader.msfragger_reader.MSFragger_PSM_TSV_Reader` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
alphabase/psm_reader/__init__.py:17:46: F401 `alphabase.psm_reader.sage_reader.SageReaderTSV` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
alphabase/psm_reader/__init__.py:17:61: F401 `alphabase.psm_reader.sage_reader.SageReaderParquet` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
alphabase/psm_reader/__init__.py:20:55: F401 `alphabase.psm_reader.msfragger_reader.MSFraggerPepXML` imported but unused; consider using `importlib.util.find_spec` to test for availability
alphabase/psm_reader/msfragger_reader.py:10:54: F401 [*] `alphabase.constants.atom.MASS_PROTON` imported but unused
alphabase/psm_reader/msfragger_reader.py:15:1: E722 Do not use bare `except`
alphabase/psm_reader/psm_reader.py:3:8: F401 [*] `io` imported but unused
alphabase/psm_reader/psm_reader.py:73:16: E713 [*] Test for membership should be `not in`
alphabase/psm_reader/psm_reader.py:342:16: E713 [*] Test for membership should be `not in`
alphabase/psm_reader/psm_reader.py:344:16: E713 [*] Test for membership should be `not in`
alphabase/psm_reader/psm_reader.py:346:16: E713 [*] Test for membership should be `not in`
alphabase/psm_reader/psm_reader.py:410:21: E713 [*] Test for membership should be `not in`
alphabase/quantification/quant_reader/config_dict_loader.py:103:8: E721 Do not compare types, use `isinstance()`
alphabase/quantification/quant_reader/config_dict_loader.py:105:19: E711 Comparison to `None` should be `cond is None`
alphabase/quantification/quant_reader/config_dict_loader.py:113:8: E721 Do not compare types, use `isinstance()`
alphabase/quantification/quant_reader/config_dict_loader.py:115:20: E711 Comparison to `None` should be `cond is None`
alphabase/quantification/quant_reader/longformat_reader.py:7:8: F401 [*] `sys` imported but unused
alphabase/quantification/quant_reader/plexdia_reformatter.py:50:1: E402 Module level import not at top of file
alphabase/quantification/quant_reader/quantreader_utils.py:2:23: E711 Comparison to `None` should be `cond is None`
alphabase/quantification/quant_reader/quantreader_utils.py:19:9: E722 Do not use bare `except`
alphabase/quantification/quant_reader/table_reformatter.py:1:8: F401 [*] `itertools` imported but unused
alphabase/quantification/quant_reader/table_reformatter.py:122:24: E711 Comparison to `None` should be `cond is None`
alphabase/quantification/quant_reader/table_reformatter.py:182:25: E711 Comparison to `None` should be `cond is not None`
alphabase/quantification/quant_reader/wideformat_reader.py:9:5: F841 Local variable `protein_cols` is assigned to but never used
alphabase/quantification/quant_reader/wideformat_reader.py:10:5: F841 Local variable `ion_cols` is assigned to but never used
alphabase/scoring/ml_scoring.py:5:26: F401 [*] `sklearn.base.BaseEstimator` imported but unused
alphabase/scoring/ml_scoring.py:10:5: F401 [*] `alphabase.scoring.fdr.calculate_fdr_from_ref` imported but unused
alphabase/scoring/ml_scoring.py:11:5: F401 [*] `alphabase.scoring.fdr.fdr_to_q_values` imported but unused
alphabase/spectral_library/base.py:261:17: F541 [*] f-string without any placeholders
alphabase/spectral_library/base.py:312:16: F401 [*] `alphabase.protein.protein_level_decoy` imported but unused
alphabase/spectral_library/decoy.py:5:23: F401 [*] `functools.partial` imported but unused
alphabase/spectral_library/decoy.py:7:30: F401 [*] `alphabase.io.hdf.HDF_File` imported but unused
alphabase/spectral_library/flat.py:10:39: F401 [*] `alphabase.peptide.precursor` imported but unused
alphabase/spectral_library/reader.py:2:8: F401 [*] `os` imported but unused
alphabase/spectral_library/reader.py:8:55: F401 [*] `alphabase.io.psm_reader.dia_search_reader.SpectronautReader` imported but unused
alphabase/spectral_library/reader.py:14:40: F401 [*] `alphabase.constants._const.CONST_FILE_FOLDER` imported but unused
alphabase/spectral_library/reader.py:15:34: F401 [*] `alphabase.yaml_utils.load_yaml` imported but unused
alphabase/spectral_library/validate.py:189:34: F541 [*] f-string without any placeholders
alphabase/statistics/regression.py:6:44: F401 [*] `sklearn.utils.estimator_checks.check_estimator` imported but unused
alphabase/statistics/regression.py:262:13: F841 Local variable `y_m` is assigned to but never used
alphabase/utils.py:2:8: F401 [*] `os` imported but unused
alphabase/utils.py:3:8: F401 [*] `sys` imported but unused
docs/conf.py:53:12: F541 [*] f-string without any placeholders
release/pyinstaller/alphabase_pyinstaller.py:8:12: F821 Undefined name `e`
setup.py:6:8: F401 [*] `os` imported but unused
Found 79 errors.
[*] 38 fixable with the `--fix` option (9 hidden fixes can be enabled with the `--unsafe-fixes` option).
```