### PR TITLE
FIX noqa by using register_reader(), address many side effects

### DIFF
--- a/alphabase/constants/element.py
+++ b/alphabase/constants/element.py
@@ -1,4 +1,4 @@
-from alphabase.constants.atom import *
+from alphabase.constants.atom import *  # noqa: F403 TODO remove in the next release
 
 import warnings
 

--- a/alphabase/io/psm_reader/__init__.py
+++ b/alphabase/io/psm_reader/__init__.py
@@ -1,2 +1,0 @@
-# Legacy, use alphabase.psm_reader instead
-from alphabase.psm_reader import *  # noqa: F403

--- a/alphabase/io/psm_reader/alphapept_reader.py
+++ b/alphabase/io/psm_reader/alphapept_reader.py
@@ -1,1 +1,0 @@
-from alphabase.psm_reader.alphapept_reader import *  # noqa: F403

--- a/alphabase/io/psm_reader/dia_psm_reader.py
+++ b/alphabase/io/psm_reader/dia_psm_reader.py
@@ -1,1 +1,0 @@
-from alphabase.psm_reader.dia_psm_reader import *  # noqa: F403

--- a/alphabase/io/psm_reader/dia_search_reader.py
+++ b/alphabase/io/psm_reader/dia_search_reader.py
@@ -1,2 +1,0 @@
-# Legacy, use .dia_psm_reader instead
-from alphabase.psm_reader.dia_psm_reader import *  # noqa: F403

--- a/alphabase/io/psm_reader/maxquant_reader.py
+++ b/alphabase/io/psm_reader/maxquant_reader.py
@@ -1,1 +1,0 @@
-from alphabase.psm_reader.maxquant_reader import *  # noqa: F403

--- a/alphabase/io/psm_reader/msfragger_reader.py
+++ b/alphabase/io/psm_reader/msfragger_reader.py
@@ -1,1 +1,0 @@
-from alphabase.psm_reader.msfragger_reader import *  # noqa: F403

--- a/alphabase/io/psm_reader/pfind_reader.py
+++ b/alphabase/io/psm_reader/pfind_reader.py
@@ -1,1 +1,0 @@
-from alphabase.psm_reader.pfind_reader import *  # noqa: F403

--- a/alphabase/io/psm_reader/psm_reader.py
+++ b/alphabase/io/psm_reader/psm_reader.py
@@ -1,1 +1,0 @@
-from alphabase.psm_reader.psm_reader import *  # noqa: F403

--- a/alphabase/peptide/fragment.py
+++ b/alphabase/peptide/fragment.py
@@ -1323,7 +1323,7 @@ def calc_fragment_cardinality(
     ):
         if len(elution_group_idx) == 0:
             return
-        elution_group_idx[0] # noqa TODO check for potential bug
+        elution_group_idx[0]  # noqa TODO check for potential bug
         elution_group_start = 0
 
         for i in range(len(elution_group_idx)):

--- a/alphabase/peptide/fragment.py
+++ b/alphabase/peptide/fragment.py
@@ -9,7 +9,7 @@ from alphabase.constants.modification import calc_modloss_mass
 from alphabase.constants.atom import (
     MASS_PROTON,
 )
-from alphabase.peptide.mass_calc import *  # noqa: F403 apparently some test code depends on things imported here TODO fix
+from alphabase.peptide.mass_calc import calc_b_y_and_peptide_masses_for_same_len_seqs
 from alphabase.peptide.precursor import (
     refine_precursor_df,
     is_precursor_refined,
@@ -403,7 +403,7 @@ def calc_fragment_mz_values_for_same_nAA(
     else:
         mod_diff_list = None
         mod_diff_site_list = None
-    (b_mass, y_mass, pepmass) = calc_b_y_and_peptide_masses_for_same_len_seqs(  # noqa: F405 TODO remove once the import is done explicitly
+    (b_mass, y_mass, pepmass) = calc_b_y_and_peptide_masses_for_same_len_seqs(
         df_group.sequence.values.astype("U"),
         mod_list,
         site_list,
@@ -1321,7 +1321,9 @@ def calc_fragment_cardinality(
         fragment_mz,
         fragment_cardinality,
     ):
-        elution_group_idx[0]  # noqa TODO check for potential bug
+        if len(elution_group_idx) == 0:
+            return
+        elution_group_idx[0]
         elution_group_start = 0
 
         for i in range(len(elution_group_idx)):

--- a/alphabase/peptide/fragment.py
+++ b/alphabase/peptide/fragment.py
@@ -1323,7 +1323,7 @@ def calc_fragment_cardinality(
     ):
         if len(elution_group_idx) == 0:
             return
-        elution_group_idx[0]
+        elution_group_idx[0] # noqa TODO check for potential bug
         elution_group_start = 0
 
         for i in range(len(elution_group_idx)):

--- a/alphabase/protein/protein_level_decoy.py
+++ b/alphabase/protein/protein_level_decoy.py
@@ -71,4 +71,5 @@ class ProteinReverseDecoy(SpecLibDecoy):
         )
 
 
-decoy_lib_provider.register("protein_reverse", ProteinReverseDecoy)
+def register_decoy():
+    decoy_lib_provider.register("protein_reverse", ProteinReverseDecoy)

--- a/alphabase/psm_reader/__init__.py
+++ b/alphabase/psm_reader/__init__.py
@@ -55,4 +55,4 @@ register_dia_readers()
 register_fragger_readers()
 register_mq_readers()
 register_pf_readers()
-register_sage_readers
+register_sage_readers()

--- a/alphabase/psm_reader/__init__.py
+++ b/alphabase/psm_reader/__init__.py
@@ -1,22 +1,54 @@
-# ruff: noqa: F401 TODO remove import side effects (i.e. change way readers are registered)
-# to register all readers into .psm_reader.psm_reader_provider
+__all__ = [
+    "psm_reader_provider",
+    "psm_reader_yaml",
+    "PSMReaderBase",
+    "AlphaPeptReader",
+    "DiannReader",
+    "SpectronautReader",
+    "SwathReader",
+    "SpectronautReportReader",
+    "MaxQuantReader",
+    "MSFragger_PSM_TSV_Reader",
+    "pFindReader",
+    "MSFraggerPepXML",
+    "SageReaderTSV",
+    "SageReaderParquet",
+]
+
 from alphabase.psm_reader.psm_reader import (
     psm_reader_provider,
     psm_reader_yaml,
     PSMReaderBase,
 )
-from alphabase.psm_reader.alphapept_reader import AlphaPeptReader, register_readers as register_ap_readers
+from alphabase.psm_reader.alphapept_reader import (
+    AlphaPeptReader,
+    register_readers as register_ap_readers,
+)
 from alphabase.psm_reader.dia_psm_reader import (
     DiannReader,
     SpectronautReader,
     SwathReader,
     SpectronautReportReader,
-    register_readers as register_dia_readers
+    register_readers as register_dia_readers,
 )
-from alphabase.psm_reader.maxquant_reader import MaxQuantReader, register_readers as register_mq_readers
-from alphabase.psm_reader.pfind_reader import pFindReader, register_readers as register_pf_readers
-from alphabase.psm_reader.msfragger_reader import MSFragger_PSM_TSV_Reader, MSFraggerPepXML, register_readers as register_fragger_readers
-from alphabase.psm_reader.sage_reader import SageReaderTSV, SageReaderParquet, register_readers as register_sage_readers
+from alphabase.psm_reader.maxquant_reader import (
+    MaxQuantReader,
+    register_readers as register_mq_readers,
+)
+from alphabase.psm_reader.pfind_reader import (
+    pFindReader,
+    register_readers as register_pf_readers,
+)
+from alphabase.psm_reader.msfragger_reader import (
+    MSFragger_PSM_TSV_Reader,
+    MSFraggerPepXML,
+    register_readers as register_fragger_readers,
+)
+from alphabase.psm_reader.sage_reader import (
+    SageReaderTSV,
+    SageReaderParquet,
+    register_readers as register_sage_readers,
+)
 
 register_ap_readers()
 register_dia_readers()

--- a/alphabase/psm_reader/__init__.py
+++ b/alphabase/psm_reader/__init__.py
@@ -5,19 +5,22 @@ from alphabase.psm_reader.psm_reader import (
     psm_reader_yaml,
     PSMReaderBase,
 )
-from alphabase.psm_reader.alphapept_reader import AlphaPeptReader
+from alphabase.psm_reader.alphapept_reader import AlphaPeptReader, register_readers as register_ap_readers
 from alphabase.psm_reader.dia_psm_reader import (
     DiannReader,
     SpectronautReader,
     SwathReader,
     SpectronautReportReader,
+    register_readers as register_dia_readers
 )
-from alphabase.psm_reader.maxquant_reader import MaxQuantReader
-from alphabase.psm_reader.pfind_reader import pFindReader
-from alphabase.psm_reader.msfragger_reader import MSFragger_PSM_TSV_Reader
-from alphabase.psm_reader.sage_reader import SageReaderTSV, SageReaderParquet
+from alphabase.psm_reader.maxquant_reader import MaxQuantReader, register_readers as register_mq_readers
+from alphabase.psm_reader.pfind_reader import pFindReader, register_readers as register_pf_readers
+from alphabase.psm_reader.msfragger_reader import MSFragger_PSM_TSV_Reader, MSFraggerPepXML, register_readers as register_fragger_readers
+from alphabase.psm_reader.sage_reader import SageReaderTSV, SageReaderParquet, register_readers as register_sage_readers
 
-try:
-    from alphabase.psm_reader.msfragger_reader import MSFraggerPepXML  # noqa: F401 TODO remove import side effects (registering the reader)
-except ImportError:
-    pass
+register_ap_readers()
+register_dia_readers()
+register_fragger_readers()
+register_mq_readers()
+register_pf_readers()
+register_sage_readers

--- a/alphabase/psm_reader/alphapept_reader.py
+++ b/alphabase/psm_reader/alphapept_reader.py
@@ -108,4 +108,5 @@ class AlphaPeptReader(PSMReaderBase):
         self._psm_df.decoy = self._psm_df.decoy.astype(np.int8)
 
 
-psm_reader_provider.register_reader("alphapept", AlphaPeptReader)
+def register_readers():
+    psm_reader_provider.register_reader("alphapept", AlphaPeptReader)

--- a/alphabase/psm_reader/dia_psm_reader.py
+++ b/alphabase/psm_reader/dia_psm_reader.py
@@ -131,13 +131,6 @@ class DiannReader(SpectronautReader):
         self._psm_df.rename(columns={"spec_idx": "diann_spec_idx"}, inplace=True)
 
 
-psm_reader_provider.register_reader("spectronaut", SpectronautReader)
-psm_reader_provider.register_reader("speclib_tsv", SpectronautReader)
-psm_reader_provider.register_reader("openswath", SwathReader)
-psm_reader_provider.register_reader("swath", SwathReader)
-psm_reader_provider.register_reader("diann", DiannReader)
-
-
 class SpectronautReportReader(MaxQuantReader):
     """Reader for Spectronaut's report TSV/CSV.
 
@@ -189,4 +182,10 @@ class SpectronautReportReader(MaxQuantReader):
         return df
 
 
-psm_reader_provider.register_reader("spectronaut_report", SpectronautReportReader)
+def register_readers():
+    psm_reader_provider.register_reader("spectronaut", SpectronautReader)
+    psm_reader_provider.register_reader("speclib_tsv", SpectronautReader)
+    psm_reader_provider.register_reader("openswath", SwathReader)
+    psm_reader_provider.register_reader("swath", SwathReader)
+    psm_reader_provider.register_reader("diann", DiannReader)
+    psm_reader_provider.register_reader("spectronaut_report", SpectronautReportReader)

--- a/alphabase/psm_reader/maxquant_reader.py
+++ b/alphabase/psm_reader/maxquant_reader.py
@@ -272,4 +272,5 @@ class MaxQuantReader(PSMReaderBase):
             self._psm_df["sequence"] = seqs
 
 
-psm_reader_provider.register_reader("maxquant", MaxQuantReader)
+def register_readers():
+    psm_reader_provider.register_reader("maxquant", MaxQuantReader)

--- a/alphabase/psm_reader/pfind_reader.py
+++ b/alphabase/psm_reader/pfind_reader.py
@@ -144,5 +144,6 @@ class pFindReader(PSMReaderBase):
         self._psm_df["mods"] = self._psm_df["mods"].apply(translate_pFind_mod)
 
 
-psm_reader_provider.register_reader("pfind", pFindReader)
-psm_reader_provider.register_reader("pfind3", pFindReader)
+def register_readers():
+    psm_reader_provider.register_reader("pfind", pFindReader)
+    psm_reader_provider.register_reader("pfind3", pFindReader)

--- a/alphabase/psm_reader/sage_reader.py
+++ b/alphabase/psm_reader/sage_reader.py
@@ -231,5 +231,6 @@ class SageReaderParquet(SageReaderBase):
         return pd.read_parquet(filename)
 
 
-psm_reader_provider.register_reader("sage_tsv", SageReaderTSV)
-psm_reader_provider.register_reader("sage_parquet", SageReaderParquet)
+def register_readers():
+    psm_reader_provider.register_reader("sage_tsv", SageReaderTSV)
+    psm_reader_provider.register_reader("sage_parquet", SageReaderParquet)

--- a/alphabase/spectral_library/base.py
+++ b/alphabase/spectral_library/base.py
@@ -309,7 +309,8 @@ class SpecLibBase(object):
         from alphabase.spectral_library.decoy import decoy_lib_provider
 
         # register 'protein_reverse' to the decoy_lib_provider
-        import alphabase.protein.protein_level_decoy  # noqa: F401 TODO this import has a side effect (registering the reader)
+        from alphabase.protein.protein_level_decoy import register_decoy
+        register_decoy()
 
         decoy_lib = decoy_lib_provider.get_decoy_lib(self.decoy, self)
         if decoy_lib is None:

--- a/alphabase/spectral_library/base.py
+++ b/alphabase/spectral_library/base.py
@@ -310,6 +310,7 @@ class SpecLibBase(object):
 
         # register 'protein_reverse' to the decoy_lib_provider
         from alphabase.protein.protein_level_decoy import register_decoy
+
         register_decoy()
 
         decoy_lib = decoy_lib_provider.get_decoy_lib(self.decoy, self)

--- a/alphabase/spectral_library/reader.py
+++ b/alphabase/spectral_library/reader.py
@@ -4,8 +4,7 @@ import pandas as pd
 from tqdm import tqdm
 
 from alphabase.peptide.mobility import mobility_to_ccs_for_df
-from alphabase.io.psm_reader.dia_search_reader import SpectronautReader  # noqa: F401 TODO this import has a side effect (registering the reader)
-from alphabase.io.psm_reader.maxquant_reader import MaxQuantReader
+from alphabase.psm_reader.maxquant_reader import MaxQuantReader
 from alphabase.spectral_library.base import SpecLibBase
 from alphabase.psm_reader.psm_reader import psm_reader_yaml
 from alphabase.psm_reader import psm_reader_provider

--- a/docs/nbs/psm_readers.ipynb
+++ b/docs/nbs/psm_readers.ipynb
@@ -23,14 +23,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from alphabase.io.psm_reader import psm_reader_provider"
+    "from alphabase.psm_reader import psm_reader_provider"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`alphabase.io.psm_reader.psm_reader_provider` has registered some basic reader classes for the following search engine results:"
+    "`alphabase.psm_reader.psm_reader_provider` has registered some basic reader classes for the following search engine results:"
    ]
   },
   {

--- a/extra_requirements/development.txt
+++ b/extra_requirements/development.txt
@@ -31,3 +31,4 @@ pydivsufsort
 pyahocorasick
 pytest
 pre-commit==3.7.0
+nbmake==1.5.3

--- a/nbs_tests/psm_reader/alphapept_reader.ipynb
+++ b/nbs_tests/psm_reader/alphapept_reader.ipynb
@@ -29,7 +29,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from alphabase.psm_reader.alphapept_reader import *"
+    "from alphabase.psm_reader.alphapept_reader import *\n",
+    "register_readers()"
    ]
   },
   {

--- a/nbs_tests/psm_reader/dia_psm_reader.ipynb
+++ b/nbs_tests/psm_reader/dia_psm_reader.ipynb
@@ -36,7 +36,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from alphabase.psm_reader.dia_psm_reader import *"
+    "from alphabase.psm_reader.dia_psm_reader import *\n",
+    "register_readers()"
    ]
   },
   {

--- a/nbs_tests/psm_reader/maxquant_reader.ipynb
+++ b/nbs_tests/psm_reader/maxquant_reader.ipynb
@@ -22,7 +22,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from alphabase.psm_reader.maxquant_reader import *"
+    "from alphabase.psm_reader.maxquant_reader import *\n",
+    "register_readers()"
    ]
   },
   {

--- a/nbs_tests/psm_reader/msfragger_reader.ipynb
+++ b/nbs_tests/psm_reader/msfragger_reader.ipynb
@@ -23,7 +23,8 @@
    "outputs": [],
    "source": [
     "from alphabase.psm_reader.msfragger_reader import *\n",
-    "from alphabase.peptide.fragment import create_fragment_mz_dataframe"
+    "from alphabase.peptide.fragment import create_fragment_mz_dataframe\n",
+    "register_readers()"
    ]
   },
   {

--- a/nbs_tests/psm_reader/pfind_reader.ipynb
+++ b/nbs_tests/psm_reader/pfind_reader.ipynb
@@ -33,7 +33,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from alphabase.psm_reader.pfind_reader import *"
+    "from alphabase.psm_reader.pfind_reader import *\n",
+    "register_readers()"
    ]
   },
   {

--- a/nbs_tests/psm_reader/sage_reader.ipynb
+++ b/nbs_tests/psm_reader/sage_reader.ipynb
@@ -26,7 +26,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from alphabase.psm_reader.sage_reader import *"
+    "from alphabase.psm_reader.sage_reader import *\n",
+    "register_readers()"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ dask
 dask_expr
 pyahocorasick
 pyteomics
+lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ regex
 dask
 dask_expr
 pyahocorasick
+pyteomics


### PR DESCRIPTION
Review this PR after #171 

Changes:

- Remove `alphabase.io.psm_reader` as all functionalities are already in `alphabase.psm_reader` module.
- register_reader() for all reader modules
- register_decoy() for protein_level_decoy