### PR TITLE
remove settings.ini from .bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -13,8 +13,6 @@ serialize =
 
 [bumpversion:file:./alphabase/__init__.py]
 
-[bumpversion:file:./settings.ini]
-
 [bumpversion:file:./docs/conf.py]
 
 [bumpversion:file:./release/one_click_linux_gui/control]


### PR DESCRIPTION
settings.ini was removed but still in bumpversion cfg