### PR TITLE
Mitigate wrong encoding under windows

### DIFF
--- a/alphabase/protein/fasta.py
+++ b/alphabase/protein/fasta.py
@@ -46,7 +46,7 @@ def read_fasta_file(fasta_filename: str = ""):
         protein information,
         {protein_id:str, full_name:str, gene_name:str, description:str, sequence:str}
     """
-    with open(fasta_filename, "rt") as handle:
+    with open(fasta_filename, "rt", encoding="utf-8", errors="ignore") as handle:
         iterator = SeqIO.parse(handle, "fasta")
         while iterator:
             try:

--- a/alphabase/protein/fasta.py
+++ b/alphabase/protein/fasta.py
@@ -46,7 +46,7 @@ def read_fasta_file(fasta_filename: str = ""):
         protein information,
         {protein_id:str, full_name:str, gene_name:str, description:str, sequence:str}
     """
-    with open(fasta_filename, "rt", encoding="utf-8", errors="ignore") as handle:
+    with open(fasta_filename, "rt", encoding="utf-8") as handle:
         iterator = SeqIO.parse(handle, "fasta")
         while iterator:
             try:


### PR DESCRIPTION
I'm not a 100% sure about the bug but I think python applies the wrong encoding in some versions of windows or locales. 
Based on the stack trace it seems like it tries to decode a file with cp1252 encoding and fails doing so.

This change forces utf8 encoding by default which is compatible with ascii.