### PR TITLE
load modseq by default

### DIFF
--- a/alphabase/spectral_library/base.py
+++ b/alphabase/spectral_library/base.py
@@ -626,7 +626,7 @@ class SpecLibBase(object):
             "fragment_intensity_df": self._fragment_intensity_df,
         }
 
-    def load_hdf(self, hdf_file: str, load_mod_seq: bool = False):
+    def load_hdf(self, hdf_file: str, load_mod_seq: bool = True):
         """Load the hdf library from hdf_file
 
         Parameters

--- a/alphabase/spectral_library/base.py
+++ b/alphabase/spectral_library/base.py
@@ -635,8 +635,9 @@ class SpecLibBase(object):
             hdf library path to load
 
         load_mod_seq : bool, optional
-            if also load mod_seq_df.
-            Defaults to False.
+            For performance reason, the susbset of non key numeric columns is stored in mod_seq_df.
+            For fast loading, set load_mod_seq to False to skip loading mod_seq_df.
+            Defaults to True.
 
         """
         _hdf = HDF_File(

--- a/nbs_tests/spectral_library/library_base.ipynb
+++ b/nbs_tests/spectral_library/library_base.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -193,7 +193,7 @@
        "5   6831658824673244137  "
       ]
      },
-     "execution_count": null,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -234,19 +234,13 @@
     "        'sequence': [1,2]\n",
     "    })\n",
     ")\n",
-    "new_lib = SpecLibBase([])\n",
-    "new_lib.load_hdf('sandbox/test_lib.hdf')\n",
     "\n",
+    "new_lib = SpecLibBase([])\n",
+    "new_lib.load_hdf('sandbox/test_lib.hdf', load_mod_seq=True)\n",
     "assert len(new_lib.precursor_df) > 0\n",
     "assert len(new_lib.fragment_mz_df) == 0\n",
     "assert len(new_lib.fragment_intensity_df) == 0\n",
     "\n",
-    "assert 'sequence' not in new_lib.precursor_df.columns\n",
-    "assert 'mod_seq_hash' in new_lib.precursor_df.columns\n",
-    "\n",
-    "\n",
-    "new_lib = SpecLibBase([])\n",
-    "new_lib.load_hdf('sandbox/test_lib.hdf', load_mod_seq=True)\n",
     "assert 'sequence' in new_lib.precursor_df.columns\n",
     "assert 'mod_seq_hash' in new_lib.precursor_df.columns\n",
     "\n",
@@ -924,6 +918,18 @@
    "display_name": "python3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This should be a stimulus for a discussion:

The original speclib base implementation aimed to be high performant and only included key numeric columns.
If any other column should be loaded or such the `load_mod_seq` key needs to be set.

This is nice but very counterintuitive. I myself have encountered multiple times where my speclib "lost" columns and I had to remember to set this flag, which has now become my default. I looked into this and I have 29 occurences where I set this in my private notebooks and 6 occurences in alphaDIA :D.

<img width="1310" alt="Screenshot 2024-07-06 at 10 50 44" src="https://github.com/MannLabs/alphabase/assets/6473148/00e0a4cb-5bca-4d9e-89b1-561a8d21b7d9">

I decided to make this PR because @boopthesnoot has also steopped into this trap but solved it in a different way:
```python
self.speclib_flat.key_numeric_columns.extend(self.speclib_flat.precursor_df.columns.to_list())
```

I Propose to:
1. Change the default behaviour to the slow but user friendly case of loading all columns (this PR).
2. Remove the concept of `key_numeric_columns` and load all columns all of the time.
