### PR TITLE
add support for fixed string arrays

### DIFF
--- a/alphabase/io/tempmmap.py
+++ b/alphabase/io/tempmmap.py
@@ -163,16 +163,10 @@ def array(shape: tuple, dtype: np.dtype, tmp_dir_abs_path: str = None) -> np.nda
         TEMP_DIR_NAME, f"temp_mmap_{np.random.randint(2**63, dtype=np.int64)}.hdf"
     )
 
-    if isinstance(dtype, np.dtypes.ObjectDType):
-        with h5py.File(temp_file_name, "w") as hdf_file:
-            array = hdf_file.create_dataset("array", shape=shape, dtype=dtype)
-            array[0] = np.string_("")
-            offset = array.id.get_offset()
-    else:
-        with h5py.File(temp_file_name, "w") as hdf_file:
-            array = hdf_file.create_dataset("array", shape=shape, dtype=dtype)
-            array[0] = 0
-            offset = array.id.get_offset()
+    with h5py.File(temp_file_name, "w") as hdf_file:
+        array = hdf_file.create_dataset("array", shape=shape, dtype=dtype)
+        array[0] = np.string_("") if isinstance(dtype, np.dtypes.ObjectDType) else 0
+        offset = array.id.get_offset()
 
     with open(temp_file_name, "rb+") as raw_hdf_file:
         mmap_obj = mmap.mmap(raw_hdf_file.fileno(), 0, access=mmap.ACCESS_WRITE)
@@ -229,14 +223,9 @@ def create_empty_mmap(
     else:
         temp_file_name = _get_file_location(file_path, overwrite=False)
 
-    if isinstance(dtype, np.dtypes.ObjectDType):
-        with h5py.File(temp_file_name, "w") as hdf_file:
-            array = hdf_file.create_dataset("array", shape=shape, dtype=dtype)
-            array[0] = np.string_("")
-    else:
-        with h5py.File(temp_file_name, "w") as hdf_file:
-            array = hdf_file.create_dataset("array", shape=shape, dtype=dtype)
-            array[0] = 0
+    with h5py.File(temp_file_name, "w") as hdf_file:
+        array = hdf_file.create_dataset("array", shape=shape, dtype=dtype)
+        array[0] = np.string_("") if isinstance(dtype, np.dtypes.ObjectDType) else 0
 
     return temp_file_name
 

--- a/alphabase/io/tempmmap.py
+++ b/alphabase/io/tempmmap.py
@@ -165,7 +165,7 @@ def array(shape: tuple, dtype: np.dtype, tmp_dir_abs_path: str = None) -> np.nda
 
     with h5py.File(temp_file_name, "w") as hdf_file:
         array = hdf_file.create_dataset("array", shape=shape, dtype=dtype)
-        array[0] = np.string_("") if isinstance(dtype, np.dtypes.ObjectDType) else 0
+        array[0] = np.string_("") if isinstance(dtype, np.dtypes.StrDType) else 0
         offset = array.id.get_offset()
 
     with open(temp_file_name, "rb+") as raw_hdf_file:
@@ -225,7 +225,7 @@ def create_empty_mmap(
 
     with h5py.File(temp_file_name, "w") as hdf_file:
         array = hdf_file.create_dataset("array", shape=shape, dtype=dtype)
-        array[0] = np.string_("") if isinstance(dtype, np.dtypes.ObjectDType) else 0
+        array[0] = np.string_("") if isinstance(dtype, np.dtypes.StrDType) else 0
 
     return temp_file_name
 

--- a/alphabase/io/tempmmap.py
+++ b/alphabase/io/tempmmap.py
@@ -237,7 +237,7 @@ def create_empty_mmap(
         with h5py.File(temp_file_name, "w") as hdf_file:
             array = hdf_file.create_dataset("array", shape=shape, dtype=dtype)
             array[0] = 0
-            
+
     return temp_file_name
 
 

--- a/alphabase/io/tempmmap.py
+++ b/alphabase/io/tempmmap.py
@@ -163,10 +163,16 @@ def array(shape: tuple, dtype: np.dtype, tmp_dir_abs_path: str = None) -> np.nda
         TEMP_DIR_NAME, f"temp_mmap_{np.random.randint(2**63, dtype=np.int64)}.hdf"
     )
 
-    with h5py.File(temp_file_name, "w") as hdf_file:
-        array = hdf_file.create_dataset("array", shape=shape, dtype=dtype)
-        array[0] = 0
-        offset = array.id.get_offset()
+    if isinstance(dtype, np.dtypes.ObjectDType):
+        with h5py.File(temp_file_name, "w") as hdf_file:
+            array = hdf_file.create_dataset("array", shape=shape, dtype=dtype)
+            array[0] = np.string_("")
+            offset = array.id.get_offset()
+    else:
+        with h5py.File(temp_file_name, "w") as hdf_file:
+            array = hdf_file.create_dataset("array", shape=shape, dtype=dtype)
+            array[0] = 0
+            offset = array.id.get_offset()
 
     with open(temp_file_name, "rb+") as raw_hdf_file:
         mmap_obj = mmap.mmap(raw_hdf_file.fileno(), 0, access=mmap.ACCESS_WRITE)
@@ -223,10 +229,15 @@ def create_empty_mmap(
     else:
         temp_file_name = _get_file_location(file_path, overwrite=False)
 
-    with h5py.File(temp_file_name, "w") as hdf_file:
-        array = hdf_file.create_dataset("array", shape=shape, dtype=dtype)
-        array[0] = 0
-
+    if isinstance(dtype, np.dtypes.ObjectDType):
+        with h5py.File(temp_file_name, "w") as hdf_file:
+            array = hdf_file.create_dataset("array", shape=shape, dtype=dtype)
+            array[0] = np.string_("")
+    else:
+        with h5py.File(temp_file_name, "w") as hdf_file:
+            array = hdf_file.create_dataset("array", shape=shape, dtype=dtype)
+            array[0] = 0
+            
     return temp_file_name
 
 


### PR DESCRIPTION
currently the memory mapped temp arrays only work with arrays of numeric types
This adds support for fixed string types. 

For e.g.:

```
#create an empty memory mapped array
dt = np.dtype(f'S{fixed_length}')
self._tmp_single_cell_index_path = create_empty_mmap(
                                        shape=single_cell_index_shape,
                                        dtype=dt,
                                        tmp_dir_abs_path=self._tmp_dir_path,
                                    )

#reconnect to the array (potentially from a different process)
 _tmp_single_cell_index = mmap_array_from_path(self._tmp_single_cell_index_path)

#add results to the array
_tmp_single_cell_index[save_index] = [save_index, cell_id]. #typing is enforced automatically here no need to convert to fixed string before hand
```