### PR TITLE
open hdf file "r" mode on read operations

### DIFF
--- a/alphabase/io/hdf.py
+++ b/alphabase/io/hdf.py
@@ -45,7 +45,7 @@ class HDF_Object:
 
     @property
     def metadata(self):
-        with h5py.File(self.file_name, "a") as hdf_file:
+        with h5py.File(self.file_name) as hdf_file:
             return dict(hdf_file[self.name].attrs)
 
     def __init__(
@@ -162,7 +162,7 @@ class HDF_Group(HDF_Object):
         group_names = []
         dataset_names = []
         datafame_names = []
-        with h5py.File(self.file_name, "a") as hdf_file:
+        with h5py.File(self.file_name) as hdf_file:
             hdf_object = hdf_file[self.name]
             for name in sorted(hdf_object):
                 if isinstance(hdf_object[name], h5py.Dataset):
@@ -328,12 +328,12 @@ class HDF_Dataset(HDF_Object):
 
     @property
     def dtype(self):
-        with h5py.File(self.file_name, "a") as hdf_file:
+        with h5py.File(self.file_name) as hdf_file:
             return hdf_file[self.name].dtype
 
     @property
     def shape(self):
-        with h5py.File(self.file_name, "a") as hdf_file:
+        with h5py.File(self.file_name) as hdf_file:
             return hdf_file[self.name].shape
 
     @property
@@ -341,7 +341,7 @@ class HDF_Dataset(HDF_Object):
         return self[...]
 
     def __getitem__(self, keys):
-        with h5py.File(self.file_name, "a") as hdf_file:
+        with h5py.File(self.file_name) as hdf_file:
             hdf_object = hdf_file[self.name]
             if h5py.check_string_dtype(hdf_object.dtype) is not None:
                 hdf_object = hdf_object.asstr()


### PR DESCRIPTION
Open HDF file in "r" mode if only read operations are done. 

This is to reduce errors ` ERROR: [Errno 11] Unable to synchronously open file (unable to lock file, errno = 11, error message = 'Resource temporarily unavailable')` on HPC systems when several instances try to access the same file.

@jalew188 alternatively one could substitute the `mode=a` with `mode="r" if self._read_only else "a"` if you see any implications here