### PR TITLE
remove maxquant MBR rows

### DIFF
--- a/alphabase/psm_reader/maxquant_reader.py
+++ b/alphabase/psm_reader/maxquant_reader.py
@@ -12,6 +12,7 @@ from alphabase.psm_reader.psm_reader import (
     psm_reader_yaml,
 )
 
+# make sure all warnings are shown
 warnings.filterwarnings("always")
 
 mod_to_unimod_dict = {}
@@ -254,13 +255,13 @@ class MaxQuantReader(PSMReaderBase):
         if "scan_num" in mapped_columns:
             scan_num_col = mapped_columns["scan_num"]
             no_ms2_mask = df[scan_num_col] == ""
-            if np.sum(no_ms2_mask) > 0:
+            if (num_no_ms2_mask := np.sum(no_ms2_mask)) > 0:
                 warnings.warn(
-                    f"Maxquant psm file contains {np.sum(no_ms2_mask)} MBR PSMs without MS2 scan. This is not yet supported and rows containing MBR PSMs will be removed."
+                    f"Maxquant psm file contains {num_no_ms2_mask} MBR PSMs without MS2 scan. This is not yet supported and rows containing MBR PSMs will be removed."
                 )
                 df = df[~no_ms2_mask]
                 df.reset_index(drop=True, inplace=True)
-                df[scan_num_col] = df[scan_num_col].astype(int)
+        df[scan_num_col] = df[scan_num_col].astype(int)
 
         # if 'K0' in df.columns:
         #     df['Mobility'] = df['K0'] # Bug in MaxQuant? It should be 1/K0

--- a/alphabase/psm_reader/maxquant_reader.py
+++ b/alphabase/psm_reader/maxquant_reader.py
@@ -1,4 +1,5 @@
 import copy
+import warnings
 
 import numba
 import numpy as np
@@ -10,6 +11,8 @@ from alphabase.psm_reader.psm_reader import (
     psm_reader_provider,
     psm_reader_yaml,
 )
+
+warnings.filterwarnings("always")
 
 mod_to_unimod_dict = {}
 for mod_name, unimod_id in MOD_DF[["mod_name", "unimod_id"]].values:
@@ -245,6 +248,20 @@ class MaxQuantReader(PSMReaderBase):
         self._find_mod_seq_column(df)
         df = df[~pd.isna(df["Retention time"])]
         df.fillna("", inplace=True)
+
+        # remove MBR PSMs as they are currently not supported and will crash import
+        mapped_columns = self._find_mapped_columns(df)
+        if "scan_num" in mapped_columns:
+            scan_num_col = mapped_columns["scan_num"]
+            no_ms2_mask = df[scan_num_col] == ""
+            if np.sum(no_ms2_mask) > 0:
+                warnings.warn(
+                    f"Maxquant psm file contains {np.sum(no_ms2_mask)} MBR PSMs without MS2 scan. This is not yet supported and rows containing MBR PSMs will be removed."
+                )
+                df = df[~no_ms2_mask]
+                df.reset_index(drop=True, inplace=True)
+                df[scan_num_col] = df[scan_num_col].astype(int)
+
         # if 'K0' in df.columns:
         #     df['Mobility'] = df['K0'] # Bug in MaxQuant? It should be 1/K0
         # min_rt = df['Retention time'].min()


### PR DESCRIPTION
currently alphabase fails for maxquant output which contains MBR PSMs.
This removes MBR PSMs and prints an explicit warning