### PR TITLE
[Documentation] Refactor documentation 

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,56 @@
+API 
+===
+
+
+Peptides 
+--------
+
+.. toctree::
+   :maxdepth: 2
+
+   modules_peptide
+
+
+Proteins
+--------
+
+.. toctree::
+   :maxdepth: 2
+
+   modules_protein
+
+
+Spectral Library
+----------------
+
+.. toctree::
+   :maxdepth: 2
+
+   modules_spectral_library
+
+
+Reader 
+------
+
+.. toctree::
+   :maxdepth: 2
+
+   modules_psm_reader
+
+
+I/O
+----
+
+.. toctree::
+   :maxdepth: 2
+
+   modules_io
+
+Constants
+---------
+
+.. toctree::
+   :maxdepth: 2
+
+   modules_constants
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ AlphaBase
 
 **Utility functions for the robust analysis of proteomics data**
 
-The infrastructure of AlphaX ecosystem for MS proteomics, originally published as part of the ``alphapeptdeep`` package [Zeng2022]_.
+The infrastructure of AlphaX ecosystem for MS proteomics [Zeng2022]_.
 For more information, see AlphaBase on `GitHub <https://github.com/MannLabs/alphabase/>`_.
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ AlphaBase
 
 **Utility functions for the robust analysis of proteomics data**
 
-The infrastructure of AlphaX ecosystem for MS proteomics, originally published as part of the ``alphapeptdeep`` package.
+The infrastructure of AlphaX ecosystem for MS proteomics, originally published as part of the ``alphapeptdeep`` package [Zeng2022]_.
 For more information, see AlphaBase on `GitHub <https://github.com/MannLabs/alphabase/>`_.
 
 
@@ -24,3 +24,9 @@ Table of Contents
    notebooks
 
    api
+
+   .. 
+
+      contributing 
+
+   references

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,17 +1,22 @@
-Documentation for AlphaBase
+AlphaBase
 =====================================
 
-The infrastructure of AlphaX ecosystem for MS proteomics.
+**Utility functions for the robust analysis of proteomics data**
+
+The infrastructure of AlphaX ecosystem for MS proteomics, originally published as part of the ``alphapeptdeep`` package.
 For more information, see AlphaBase on `GitHub <https://github.com/MannLabs/alphabase/>`_.
 
+
+..
+   Overview
+   --------
+   Add a more detailed overview of the package and the purpose. 
+
+
+Table of Contents
+-----------------
+
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    notebooks
-
-   modules_protein
-   modules_spectral_library
-   modules_peptide
-   modules_constants
-   modules_io
-   modules_psm_reader

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,8 @@ Table of Contents
 .. toctree::
    :maxdepth: 1
 
+   installation
+
    notebooks
 
    api

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,3 +20,5 @@ Table of Contents
    :maxdepth: 1
 
    notebooks
+
+   api

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,41 @@
+Installation
+============
+
+AlphaBase can be installed and used on all major operating systems (Windows, MacOS and Linux). There are two different types of installation possible:
+
+
+Users
+-----
+
+Users can install AlphaBase as a Python package in an existing Python environment.
+
+::  
+
+    ## Optional: create a python environment
+    # conda create -n alphabase python=3.9
+
+    pip install alphabase
+
+To enforce stringent dependencies, you can install the stable version of AlphaBase
+
+::
+
+    pip install "alphabase[stable]"
+
+
+Development version
+-------------------
+For development, clone the latest version from GitHub to an appropriate location on your personal device and install an editable version:
+
+:: 
+
+    ## Optional: Create development environment 
+    # conda create -n alphabase_dev python=3.9
+    # conda activate alphabase_dev
+
+    # Clone repository
+    git clone https://github.com/MannLabs/alphabase.git
+    cd alphabase
+
+    # Install editable development version 
+    pip install -e "./alphabase[development]"

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -1,0 +1,5 @@
+References
+==========
+
+.. [Zeng2022] Zeng, W.-F. et al. AlphaPeptDeep: a modular deep learning framework to predict peptide properties for proteomics. Nat Commun 13, 7238 (2022).
+


### PR DESCRIPTION
Restructure `alphabase` documentation 

This pull request 
- Adds installation instructions (`[...]/docs/installation.rst`)
- Adds a API documentation for all modules (`[...]/docs/api.rst`)
- Adds references (`[...]/docs/references.rst`)

- Restructures index page (add links to installation, API documentation, notebooks, references), adds description + reference. 

## Index 
![OLD-INDEX](https://github.com/user-attachments/assets/d25ec9f7-8016-4f24-bec8-3f5c1023143f)
![NEW-INDEX](https://github.com/user-attachments/assets/d1cee4b4-bc94-467b-a918-e822c9a44b0c)

## API 
![API](https://github.com/user-attachments/assets/d6d2f303-106c-449d-ac46-5a1da254c4ad)


