### PR TITLE
updtes in psm reader

### DIFF
--- a/alphabase/constants/const_files/psm_reader.yaml
+++ b/alphabase/constants/const_files/psm_reader.yaml
@@ -49,6 +49,10 @@ maxquant:
     'intensity': 'Intensity'
 
   modification_mapping:
+    'mTRAQ@K':
+      - 'K(mTRAQ)'
+    'mTRAQ@Any_N-term':
+      - '(mTRAQ)'
     'Dimethyl@K':
       - 'K(Dimethyl)'
     'Dimethyl@R':
@@ -131,7 +135,6 @@ msfragger_pepxml:
     'query_id': 'spectrum'
     'scan_num': 'start_scan'
     'score': 'expect'
-    'fdr': 'expect'
     'proteins': 'protein'
     'raw_name': 'raw_name'
     'mobility': 'ion_mobility'


### PR DESCRIPTION
- add mtraq to the default modification mapping
- msfragger pep.xml is missing an fdr field and has currently one of the scores set as FDR. This behaviour loads only half the entries in the pep.xml