### PR TITLE
Refactor tempmmap

### DIFF
--- a/alphabase/io/tempmmap.py
+++ b/alphabase/io/tempmmap.py
@@ -85,14 +85,16 @@ def _get_file_location(abs_file_path: str, overwrite=False) -> str:
 
     # ensure that the filename conforms to the naming convention
     if not os.path.basename(abs_file_path).endswith(".hdf"):
-        raise ValueError("The chosen file name needs to end with .hdf")
+        raise ValueError(
+            f"The chosen file name '{os.path.basename(abs_file_path)}' needs to end with .hdf"
+        )
 
     # ensure that the directory in which the file should be created exists
     if os.path.isdir(os.path.dirname(abs_file_path)):
         return abs_file_path
     else:
         raise ValueError(
-            f"The directory {os.path.commonpath(abs_file_path)} in which the file should be created does not exist."
+            f"The directory '{os.path.dirname(abs_file_path)}' in which the file should be created does not exist."
         )
 
 
@@ -221,13 +223,15 @@ def create_empty_mmap(
             TEMP_DIR_NAME, f"temp_mmap_{np.random.randint(2**63, dtype=np.int64)}.hdf"
         )
     else:
-        temp_file_name = _get_file_location(file_path, overwrite=False)
+        temp_file_name = _get_file_location(
+            file_path, overwrite=False
+        )  # TODO overwrite=overwrite
 
     with h5py.File(temp_file_name, "w") as hdf_file:
         array = hdf_file.create_dataset("array", shape=shape, dtype=dtype)
         array[0] = np.string_("") if isinstance(dtype, np.dtypes.StrDType) else 0
 
-    return temp_file_name
+    return temp_file_name  # TODO temp_file_path
 
 
 def mmap_array_from_path(hdf_file: str) -> np.ndarray:

--- a/alphabase/io/tempmmap.py
+++ b/alphabase/io/tempmmap.py
@@ -25,14 +25,14 @@ def _init_temp_dir(prefix: str = "temp_mmap_") -> str:
         TEMP_DIR_NAME = _TEMP_DIR.name
 
         logging.info(
-            f"Temporary memory-mapped arrays are written to {TEMP_DIR_NAME}. "
+            f"Temp mmap arrays are written to {TEMP_DIR_NAME}. "
             "Cleanup of this folder is OS dependent and might need to be triggered manually!"
         )
 
     return TEMP_DIR_NAME
 
 
-def _change_temp_dir_location(abs_path: str) -> None:
+def _change_temp_dir_location(abs_path: str) -> str:
     """
     Check if the directory to which the temp arrays should be written exists, if so defines this as the new temp dir location. If not raise a value error.
 
@@ -314,7 +314,7 @@ def _clear() -> None:
 
     if _TEMP_DIR is not None:
         logging.warning(
-            f"Folder {TEMP_DIR_NAME} with temporary memory-mapped arrays is being deleted. "
+            f"Folder {TEMP_DIR_NAME} with temp mmap arrays is being deleted. "
             "All existing temp mmapp arrays will be unusable!"
         )
 

--- a/alphabase/io/tempmmap.py
+++ b/alphabase/io/tempmmap.py
@@ -1,38 +1,38 @@
-#!python
-"""This module allows to create temporary mmapped arrays."""
+"""This module allows to create temporary memory-mapped arrays."""
 
-# builtin
 import atexit
 import logging
 import mmap
 import os
 import shutil
 import tempfile
+from typing import Optional
 
 import h5py
-
-# external
 import numpy as np
 
-# TODO initialize temp_dir not on import but when it is first needed
-_TEMP_DIR = tempfile.TemporaryDirectory(prefix="temp_mmap_")
-TEMP_DIR_NAME = _TEMP_DIR.name
-
-is_cleanup_info_logged = False
+_TEMP_DIR: Optional[tempfile.TemporaryDirectory] = None
+TEMP_DIR_NAME = Optional[None]
 
 
-def _log_cleanup_info_once() -> None:
-    """Logs a info on temp array cleanup once."""
-    global is_cleanup_info_logged
-    if not is_cleanup_info_logged:
+def _init_temp_dir(prefix: str = "temp_mmap_") -> str:
+    """Initialize the temporary directory for the temp mmap arrays if not already done."""
+
+    global _TEMP_DIR, TEMP_DIR_NAME
+
+    if _TEMP_DIR is None:
+        _TEMP_DIR = tempfile.TemporaryDirectory(prefix=prefix)
+        TEMP_DIR_NAME = _TEMP_DIR.name
+
         logging.info(
-            f"Temp mmap arrays are written to {TEMP_DIR_NAME}. "
+            f"Temporary memory-mapped arrays are written to {TEMP_DIR_NAME}. "
             "Cleanup of this folder is OS dependent and might need to be triggered manually!"
         )
-        is_cleanup_info_logged = True
+
+    return TEMP_DIR_NAME
 
 
-def _change_temp_dir_location(abs_path: str) -> str:
+def _change_temp_dir_location(abs_path: str) -> None:
     """
     Check if the directory to which the temp arrays should be written exists, if so defines this as the new temp dir location. If not raise a value error.
 
@@ -152,17 +152,16 @@ def array(shape: tuple, dtype: np.dtype, tmp_dir_abs_path: str = None) -> np.nda
     type
         A writable temporary mmapped array.
     """
-    global TEMP_DIR_NAME
-
-    _log_cleanup_info_once()
+    temp_dir_name = _init_temp_dir()
 
     # redefine the temporary directory if a new location is given otherwise read from global variable
     # this allows you to ensure that the correct temp directory location is used when working with multiple threads
     if tmp_dir_abs_path is not None:
         _change_temp_dir_location(tmp_dir_abs_path)
+        temp_dir_name = tmp_dir_abs_path
 
     temp_file_name = os.path.join(
-        TEMP_DIR_NAME, f"temp_mmap_{np.random.randint(2**63, dtype=np.int64)}.hdf"
+        temp_dir_name, f"temp_mmap_{np.random.randint(2**63, dtype=np.int64)}.hdf"
     )
 
     with h5py.File(temp_file_name, "w") as hdf_file:
@@ -208,19 +207,19 @@ def create_empty_mmap(
     str
         path to the newly created file.
     """
-    global TEMP_DIR_NAME
 
-    _log_cleanup_info_once()
+    temp_dir_name = _init_temp_dir()
 
     # redefine the temporary directory if a new location is given otherwise read from global variable
     # this allows you to ensure that the correct temp directory location is used when working with multiple threads
     if tmp_dir_abs_path is not None:
         _change_temp_dir_location(tmp_dir_abs_path)
+        temp_dir_name = tmp_dir_abs_path
 
     # if path does not exist generate a random file name in the TEMP directory
     if file_path is None:
         temp_file_name = os.path.join(
-            TEMP_DIR_NAME, f"temp_mmap_{np.random.randint(2**63, dtype=np.int64)}.hdf"
+            temp_dir_name, f"temp_mmap_{np.random.randint(2**63, dtype=np.int64)}.hdf"
         )
     else:
         temp_file_name = _get_file_location(
@@ -247,7 +246,6 @@ def mmap_array_from_path(hdf_file: str) -> np.ndarray:
     type
         A writable temporary mmapped array.
     """
-    _log_cleanup_info_once()
 
     path = os.path.join(hdf_file)
 
@@ -307,8 +305,25 @@ def ones(shape: tuple, dtype: np.dtype) -> np.ndarray:
 
 
 @atexit.register
-def clear() -> str:
+def _clear() -> None:
     """Reset the temporary folder containing temp mmapped arrays.
+
+    WARNING: All existing temp mmapp arrays will be unusable!
+    """
+    global _TEMP_DIR, TEMP_DIR_NAME
+
+    if _TEMP_DIR is not None:
+        logging.warning(
+            f"Folder {TEMP_DIR_NAME} with temporary memory-mapped arrays is being deleted. "
+            "All existing temp mmapp arrays will be unusable!"
+        )
+
+        del _TEMP_DIR
+        TEMP_DIR_NAME = None
+
+
+def clear() -> str:
+    """Reset the temporary folder containing temp mmapped arrays and create a new one.
 
     WARNING: All existing temp mmapp arrays will be unusable!
 
@@ -317,15 +332,8 @@ def clear() -> str:
     str
         The name of the new temporary folder.
     """
-    global _TEMP_DIR, TEMP_DIR_NAME
+    _clear()
 
-    logging.warning(
-        f"Folder {TEMP_DIR_NAME} with temp mmap arrays is being deleted. "
-        "All existing temp mmapp arrays will be unusable!"
-    )
+    temp_dir_name = _init_temp_dir()
 
-    del _TEMP_DIR
-
-    _TEMP_DIR = tempfile.TemporaryDirectory(prefix="temp_mmap_")
-    TEMP_DIR_NAME = _TEMP_DIR.name
-    return TEMP_DIR_NAME
+    return temp_dir_name

--- a/tests/unit/io/test_tempmmap.py
+++ b/tests/unit/io/test_tempmmap.py
@@ -1,0 +1,30 @@
+"""Unit tests for the tempmmap module.
+
+This module has a nontrivial lifecycle (top-level code), therefore the test setup is a bit unusual
+(explicit handling of module (un)loading in setup_function()/teardown_function())
+"""
+
+import sys
+
+import numpy as np
+
+
+def setup_function(function):
+    """Import the module before evert"""
+
+
+def teardown_function(function):
+    # simulating @atexit.register
+    sys.modules["alphabase.io.tempmmap"].clear()
+    del sys.modules["alphabase.io.tempmmap"]
+
+
+def test_create_array_with_valid_shape_and_dtype():
+    """Test creating and accessing an array."""
+    tempmmap = sys.modules["alphabase.io.tempmmap"]
+    arr = tempmmap.array((10, 10), np.float32)
+    arr[1, 1] = 1
+
+    assert arr.shape == (10, 10)
+    assert arr.dtype == np.float32
+    assert arr[1, 1] == 1

--- a/tests/unit/io/test_tempmmap.py
+++ b/tests/unit/io/test_tempmmap.py
@@ -4,6 +4,7 @@ This module has a nontrivial lifecycle (top-level code), therefore the test setu
 (explicit handling of module (un)loading in setup_function()/teardown_function())
 """
 
+import os
 import sys
 import tempfile
 
@@ -51,16 +52,39 @@ def test_create_array_with_custom_temp_dir():
         # when
         arr = tempmmap.array((5, 5), np.int32, tmp_dir_abs_path=temp_dir)
 
-    assert arr.shape == (5, 5)
-    assert arr.dtype == np.int32
-    assert arr[1, 1] == 0
+        assert arr.shape == (5, 5)
+        assert arr.dtype == np.int32
+        assert arr[1, 1] == 0
 
-    # test rw access to array
-    arr[1, 1] = 1
-    assert arr[1, 1] == 1
+        # test rw access to array
+        arr[1, 1] = 1
+        assert arr[1, 1] == 1
 
     assert tempmmap._TEMP_DIR is not None
     assert temp_dir == tempmmap.TEMP_DIR_NAME
+
+
+def test_mmap_array_from_path():
+    tempmmap = sys.modules["alphabase.io.tempmmap"]
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # first create an array ..
+        arr = tempmmap.array((5, 5), np.int32, tmp_dir_abs_path=temp_dir)
+        arr[1, 1] = 1
+
+        # then reconnect to it
+        temp_dir = tempmmap.TEMP_DIR_NAME
+        # this is a bit hacky but given all the randomness in the temp file name, should be ok:
+        temp_file_name = os.listdir(temp_dir)[0]
+
+        reconnected_arr = tempmmap.mmap_array_from_path(f"{temp_dir}/{temp_file_name}")
+        assert reconnected_arr[1, 1] == 1
+
+        reconnected_arr[1, 1] = 2
+        assert reconnected_arr[1, 1] == 2
+
+        arr[1, 1] = 3
+        assert reconnected_arr[1, 1] == 3
 
 
 def test_create_zeros():

--- a/tests/unit/io/test_tempmmap.py
+++ b/tests/unit/io/test_tempmmap.py
@@ -197,3 +197,16 @@ def test_create_ones():
     assert arr.dtype == np.int32
 
     assert tempmmap._TEMP_DIR is not None
+
+
+def test_redefine_location():
+    """Test redefining temp location."""
+    tempmmap = sys.modules["alphabase.io.tempmmap"]
+
+    old_temp_dir = tempmmap._TEMP_DIR
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        tempmmap.redefine_temp_location(temp_dir)
+
+    assert old_temp_dir != tempmmap._TEMP_DIR
+    assert os.path.dirname(tempmmap.TEMP_DIR_NAME) == temp_dir

--- a/tests/unit/io/test_tempmmap.py
+++ b/tests/unit/io/test_tempmmap.py
@@ -41,6 +41,8 @@ def test_create_array():
     arr[1, 1] = 1
     assert arr[1, 1] == 1
 
+    assert tempmmap._TEMP_DIR is not None
+
 
 def test_create_array_with_custom_temp_dir():
     tempmmap = sys.modules["alphabase.io.tempmmap"]
@@ -48,10 +50,40 @@ def test_create_array_with_custom_temp_dir():
     with tempfile.TemporaryDirectory() as temp_dir:
         # when
         arr = tempmmap.array((5, 5), np.int32, tmp_dir_abs_path=temp_dir)
-        assert arr.shape == (5, 5)
-        assert arr.dtype == np.int32
-        assert arr[1, 1] == 0
 
-        # test rw access to array
-        arr[1, 1] = 1
-        assert arr[1, 1] == 1
+    assert arr.shape == (5, 5)
+    assert arr.dtype == np.int32
+    assert arr[1, 1] == 0
+
+    # test rw access to array
+    arr[1, 1] = 1
+    assert arr[1, 1] == 1
+
+    assert tempmmap._TEMP_DIR is not None
+    assert temp_dir == tempmmap.TEMP_DIR_NAME
+
+
+def test_create_zeros():
+    """Test creating and accessing an array of zeros."""
+    tempmmap = sys.modules["alphabase.io.tempmmap"]
+
+    # when
+    arr = tempmmap.zeros((5, 5), np.int32)
+    assert arr[1, 1] == 0
+    assert arr.shape == (5, 5)
+    assert arr.dtype == np.int32
+
+    assert tempmmap._TEMP_DIR is not None
+
+
+def test_create_ones():
+    """Test creating and accessing an array of ones."""
+    tempmmap = sys.modules["alphabase.io.tempmmap"]
+
+    # when
+    arr = tempmmap.ones((5, 5), np.int32)
+    assert arr[1, 1] == 1
+    assert arr.shape == (5, 5)
+    assert arr.dtype == np.int32
+
+    assert tempmmap._TEMP_DIR is not None

--- a/tests/unit/io/test_tempmmap.py
+++ b/tests/unit/io/test_tempmmap.py
@@ -20,7 +20,7 @@ def setup_function(function):
 def teardown_function(function):
     """Simulate `atexit.register` and delete the module before every test."""
     tempmmap = sys.modules["alphabase.io.tempmmap"]
-    tempmmap.clear()  # simulating @atexit.register
+    tempmmap._clear()  # simulating @atexit.register
 
     # # later:
     # assert tempmmap._TEMP_DIR is None

--- a/tests/unit/io/test_tempmmap.py
+++ b/tests/unit/io/test_tempmmap.py
@@ -5,26 +5,53 @@ This module has a nontrivial lifecycle (top-level code), therefore the test setu
 """
 
 import sys
+import tempfile
 
 import numpy as np
 
 
 def setup_function(function):
-    """Import the module before evert"""
+    """Import the module before every test."""
+    import alphabase.io.tempmmap  # noqa
 
 
 def teardown_function(function):
-    # simulating @atexit.register
-    sys.modules["alphabase.io.tempmmap"].clear()
+    """Simulate `atexit.register` and delete the module before every test."""
+    tempmmap = sys.modules["alphabase.io.tempmmap"]
+    tempmmap.clear()  # simulating @atexit.register
+
+    # # later:
+    # assert tempmmap._TEMP_DIR is None
+    # assert tempmmap.TEMP_DIR_NAME is None
+
     del sys.modules["alphabase.io.tempmmap"]
 
 
-def test_create_array_with_valid_shape_and_dtype():
+def test_create_array():
     """Test creating and accessing an array."""
     tempmmap = sys.modules["alphabase.io.tempmmap"]
-    arr = tempmmap.array((10, 10), np.float32)
-    arr[1, 1] = 1
 
-    assert arr.shape == (10, 10)
+    # when
+    arr = tempmmap.array((5, 5), np.float32)
+    assert arr[1, 1] == 0
+    assert arr.shape == (5, 5)
     assert arr.dtype == np.float32
+
+    # test rw access to array
+    arr[1, 1] = 1
     assert arr[1, 1] == 1
+
+
+def test_create_array_with_custom_temp_dir():
+    tempmmap = sys.modules["alphabase.io.tempmmap"]
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # when
+        arr = tempmmap.array((5, 5), np.int32, tmp_dir_abs_path=temp_dir)
+        assert arr.shape == (5, 5)
+        assert arr.dtype == np.int32
+        assert arr[1, 1] == 0
+
+        # test rw access to array
+        arr[1, 1] = 1
+        assert arr[1, 1] == 1

--- a/tests/unit/io/test_tempmmap.py
+++ b/tests/unit/io/test_tempmmap.py
@@ -47,6 +47,7 @@ def test_create_array():
 
 
 def test_create_array_with_custom_temp_dir():
+    """Test creating and accessing an array with custom temp dir."""
     tempmmap = sys.modules["alphabase.io.tempmmap"]
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -66,6 +67,7 @@ def test_create_array_with_custom_temp_dir():
 
 
 def test_mmap_array_from_path():
+    """Test reconnecting to an existing array."""
     tempmmap = sys.modules["alphabase.io.tempmmap"]
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -108,7 +110,7 @@ def test_create_empty():
 
 
 def test_create_empty_with_custom_temp_dir():
-    """Test creating and accessing an empty array."""
+    """Test creating and accessing an empty array with custom temp dir."""
     tempmmap = sys.modules["alphabase.io.tempmmap"]
 
     # when
@@ -131,7 +133,7 @@ def test_create_empty_with_custom_temp_dir():
 
 
 def test_create_empty_with_custom_file_path():
-    """Test creating and accessing an empty array."""
+    """Test creating and accessing an empty array with custom file path."""
     tempmmap = sys.modules["alphabase.io.tempmmap"]
 
     # when
@@ -155,7 +157,7 @@ def test_create_empty_with_custom_file_path():
 
 
 def test_create_empty_with_custom_file_path_error_cases():
-    """Test creating and accessing an empty array."""
+    """Test creating and accessing an empty array: error cases."""
     tempmmap = sys.modules["alphabase.io.tempmmap"]
 
     # when


### PR DESCRIPTION
- put tempmmap.py under test (done before the refactoring)
- create temporary directories not on module import but on demand
- avoid unnecessary creation of temporary directory at program exit
