### PR TITLE
'alphabase.peptide.fragment.py' bug fix

### DIFF
--- a/alphabase/peptide/fragment.py
+++ b/alphabase/peptide/fragment.py
@@ -928,13 +928,13 @@ def remove_unused_fragments(
         returns the reindexed precursor DataFrame and the sliced fragment DataFrames
     """
 
-    precursor_df = precursor_df.sort_values([frag_start_col], ascending=True)
+
     frag_idx = precursor_df[[frag_start_col, frag_stop_col]].values
 
     new_frag_idx, fragment_pointer = compress_fragment_indices(frag_idx)
 
     precursor_df[[frag_start_col, frag_stop_col]] = new_frag_idx
-    precursor_df = precursor_df.sort_index()
+    precursor_df = precursor_df.reset_index(drop=True)
 
     output_tuple = []
 


### PR DESCRIPTION
In `compress_fragment_indices()`, the `frag_start_col` has already been sorted in ascending order. Therefore, there is no need to use `sort_values()` before calling `compress_fragment_indices`. Doing so may disrupt the order of `nAA` or other sequential attributes.

Similarly, using `sort_index()` might compromise the ordered nature of `frag_start_col`. To prevent this, it should be replaced with `reset_index()`.