### PR TITLE
[Fix] Add alphabase as dependency to readthedocs setup

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,4 +22,6 @@ sphinx:
 # # Optionally set the version of Python and requirements required to build your docs
 python:
   install:
+    - method: pip
+      path: .
     - requirements: extra_requirements/development.txt


### PR DESCRIPTION
Install `alphabase` during compilation of docs to enable API documentation. 

Comparison of (local) compilations:

**Before** 
![image](https://github.com/user-attachments/assets/720a7b6e-1860-4c57-9869-a7c82cbb43b7)


**After**
![image](https://github.com/user-attachments/assets/759a6f92-565a-4979-b6eb-97a990d786a6)