### PR TITLE
Refactor fdr

### DIFF
--- a/alphabase/psm_reader/psm_reader.py
+++ b/alphabase/psm_reader/psm_reader.py
@@ -235,13 +235,13 @@ class PSMReaderBase(ABC):
 
             origin_df = self._pre_process(origin_df)
             self._translate_columns(origin_df)  # only here
-            self._filter_fdr()
             self._translate_decoy()  # only sage, mq, msfragger, pfind
             self._translate_score()  # only msfragger, pfind
             self._load_modifications(
                 origin_df
             )  # only sage, mq, msfragger, pfind, alphapept
             self._translate_modifications()  # here, sage, msfragger, pfind
+            self._filter_fdr()
             self._post_process(origin_df)  # here, libraryreader, diann, msfragger
         return self._psm_df
 
@@ -334,8 +334,8 @@ class PSMReaderBase(ABC):
 
         self._psm_df = self._psm_df[~self._psm_df[PsmDfCols.MODS].isna()]
 
-        if PsmDfCols.DECOY in self._psm_df.columns and not self._keep_decoy:
-            self._psm_df = self._psm_df[self._psm_df[PsmDfCols.DECOY] == 0]
+        # if PsmDfCols.DECOY in self._psm_df.columns and not self._keep_decoy:
+        #     self._psm_df = self._psm_df[self._psm_df[PsmDfCols.DECOY] == 0]
 
         reset_precursor_df(self._psm_df)
 

--- a/alphabase/psm_reader/psm_reader.py
+++ b/alphabase/psm_reader/psm_reader.py
@@ -334,8 +334,8 @@ class PSMReaderBase(ABC):
 
         self._psm_df = self._psm_df[~self._psm_df[PsmDfCols.MODS].isna()]
 
-        if PsmDfCols.DECOY in self._psm_df.columns and not self._keep_decoy:
-            self._psm_df = self._psm_df[self._psm_df[PsmDfCols.DECOY] == 0]
+        # if PsmDfCols.DECOY in self._psm_df.columns and not self._keep_decoy:
+        #     self._psm_df = self._psm_df[self._psm_df[PsmDfCols.DECOY] == 0]
 
         reset_precursor_df(self._psm_df)
 

--- a/alphabase/psm_reader/psm_reader.py
+++ b/alphabase/psm_reader/psm_reader.py
@@ -235,6 +235,7 @@ class PSMReaderBase(ABC):
 
             origin_df = self._pre_process(origin_df)
             self._translate_columns(origin_df)  # only here
+            self._filter_fdr()
             self._translate_decoy()  # only sage, mq, msfragger, pfind
             self._translate_score()  # only msfragger, pfind
             self._load_modifications(
@@ -333,8 +334,6 @@ class PSMReaderBase(ABC):
 
         self._psm_df = self._psm_df[~self._psm_df[PsmDfCols.MODS].isna()]
 
-        self._psm_df = self._filter_fdr(self._psm_df)
-
         if PsmDfCols.DECOY in self._psm_df.columns and not self._keep_decoy:
             self._psm_df = self._psm_df[self._psm_df[PsmDfCols.DECOY] == 0]
 
@@ -358,12 +357,10 @@ class PSMReaderBase(ABC):
                 self._psm_df, PsmDfCols.MOBILITY
             )
 
-    def _filter_fdr(self, psm_df: pd.DataFrame) -> pd.DataFrame:
+    def _filter_fdr(self) -> pd.DataFrame:
         """Filter PSMs by FDR."""
-        if PsmDfCols.FDR not in psm_df.columns:
-            return psm_df
-
-        return psm_df[psm_df[PsmDfCols.FDR] <= self._keep_fdr]
+        if PsmDfCols.FDR in self._psm_df.columns:
+            self._psm_df = self._psm_df[self._psm_df[PsmDfCols.FDR] <= self._keep_fdr]
 
     def normalize_rt_by_raw_name(self) -> None:
         """Normalize RT by raw name."""

--- a/alphabase/psm_reader/psm_reader.py
+++ b/alphabase/psm_reader/psm_reader.py
@@ -334,8 +334,8 @@ class PSMReaderBase(ABC):
 
         self._psm_df = self._psm_df[~self._psm_df[PsmDfCols.MODS].isna()]
 
-        # if PsmDfCols.DECOY in self._psm_df.columns and not self._keep_decoy:
-        #     self._psm_df = self._psm_df[self._psm_df[PsmDfCols.DECOY] == 0]
+        if PsmDfCols.DECOY in self._psm_df.columns and not self._keep_decoy:
+            self._psm_df = self._psm_df[self._psm_df[PsmDfCols.DECOY] == 0]
 
         reset_precursor_df(self._psm_df)
 

--- a/alphabase/psm_reader/psm_reader.py
+++ b/alphabase/psm_reader/psm_reader.py
@@ -145,7 +145,7 @@ class PSMReaderBase(ABC):
 
         self._psm_df = None
 
-        self._keep_fdr = fdr
+        self._fdr_threshold = fdr
         self._keep_decoy = keep_decoy
 
         self._precursor_id_columns = psm_reader_yaml[self._reader_type].get(
@@ -360,7 +360,9 @@ class PSMReaderBase(ABC):
     def _filter_fdr(self) -> None:
         """Filter PSMs by FDR."""
         if PsmDfCols.FDR in self._psm_df.columns:
-            self._psm_df = self._psm_df[self._psm_df[PsmDfCols.FDR] <= self._keep_fdr]
+            self._psm_df = self._psm_df[
+                self._psm_df[PsmDfCols.FDR] <= self._fdr_threshold
+            ]
 
     def normalize_rt_by_raw_name(self) -> None:
         """Normalize RT by raw name."""

--- a/alphabase/psm_reader/psm_reader.py
+++ b/alphabase/psm_reader/psm_reader.py
@@ -357,7 +357,7 @@ class PSMReaderBase(ABC):
                 self._psm_df, PsmDfCols.MOBILITY
             )
 
-    def _filter_fdr(self) -> pd.DataFrame:
+    def _filter_fdr(self) -> None:
         """Filter PSMs by FDR."""
         if PsmDfCols.FDR in self._psm_df.columns:
             self._psm_df = self._psm_df[self._psm_df[PsmDfCols.FDR] <= self._keep_fdr]

--- a/alphabase/psm_reader/sage_reader.py
+++ b/alphabase/psm_reader/sage_reader.py
@@ -613,9 +613,13 @@ class SageReaderBase(PSMReaderBase, ABC):
         self.mp_process_num = mp_process_num
 
     def _translate_decoy(self) -> None:
-        # TODO: this is not doing what the name pretends, plus there's a redundancy with post_process
+        # TODO: there's a redundancy with post_process
         if not self._keep_decoy:
             self._psm_df = self._psm_df[~self._psm_df[PsmDfCols.DECOY]]
+
+    def _filter_fdr(self) -> None:
+        """Filter PSMs by FDR."""
+        super()._filter_fdr()
 
         self._psm_df = self._psm_df[
             self._psm_df[PsmDfCols.PEPTIDE_FDR] <= self._keep_fdr
@@ -624,7 +628,6 @@ class SageReaderBase(PSMReaderBase, ABC):
             self._psm_df[PsmDfCols.PROTEIN_FDR] <= self._keep_fdr
         ]
 
-        # drop peptide_fdr, protein_fdr
         self._psm_df.drop(
             columns=[PsmDfCols.PEPTIDE_FDR, PsmDfCols.PROTEIN_FDR], inplace=True
         )

--- a/alphabase/psm_reader/sage_reader.py
+++ b/alphabase/psm_reader/sage_reader.py
@@ -617,7 +617,8 @@ class SageReaderBase(PSMReaderBase, ABC):
         if not self._keep_decoy:
             self._psm_df = self._psm_df[~self._psm_df[PsmDfCols.DECOY]]
 
-        self._psm_df = self._psm_df[self._psm_df[PsmDfCols.FDR] <= self._keep_fdr]
+        self._psm_df = self._filter_fdr(self._psm_df)
+
         self._psm_df = self._psm_df[
             self._psm_df[PsmDfCols.PEPTIDE_FDR] <= self._keep_fdr
         ]

--- a/alphabase/psm_reader/sage_reader.py
+++ b/alphabase/psm_reader/sage_reader.py
@@ -617,8 +617,6 @@ class SageReaderBase(PSMReaderBase, ABC):
         if not self._keep_decoy:
             self._psm_df = self._psm_df[~self._psm_df[PsmDfCols.DECOY]]
 
-        self._psm_df = self._filter_fdr(self._psm_df)
-
         self._psm_df = self._psm_df[
             self._psm_df[PsmDfCols.PEPTIDE_FDR] <= self._keep_fdr
         ]

--- a/alphabase/psm_reader/sage_reader.py
+++ b/alphabase/psm_reader/sage_reader.py
@@ -622,10 +622,10 @@ class SageReaderBase(PSMReaderBase, ABC):
         super()._filter_fdr()
 
         self._psm_df = self._psm_df[
-            self._psm_df[PsmDfCols.PEPTIDE_FDR] <= self._keep_fdr
+            self._psm_df[PsmDfCols.PEPTIDE_FDR] <= self._fdr_threshold
         ]
         self._psm_df = self._psm_df[
-            self._psm_df[PsmDfCols.PROTEIN_FDR] <= self._keep_fdr
+            self._psm_df[PsmDfCols.PROTEIN_FDR] <= self._fdr_threshold
         ]
 
         self._psm_df.drop(


### PR DESCRIPTION
Refactor FDR handling to prepare for extended DIANN filtering:
- do it in a dedicated method

Moving it up in the hierarchy (right after reading) is a bit tricky due to`_load_modifications` relyin on `psm_df` and `origin_df` having the same shape..
Is it worth moving it up (e.g. in terms of speed) @GeorgWa @jalew188 ?


