### PR TITLE
[Documentation | Fixes] Fix docs

### DIFF
--- a/alphabase/constants/atom.py
+++ b/alphabase/constants/atom.py
@@ -95,11 +95,18 @@ MASS_NH3: int = None
 
 
 def update_atom_infos(new_atom_info: typing.Dict):
-    """
+    """Update the atom information in CHEM_INFO_DICT.
+
     Args:
-        atom_dict (Dict): Example, replacing N with 15N
+        new_atom_info (Dict): A dictionary specifying new isotopic abundances and masses.
+
+    Examples:
+        Replacing N with 15N
+
+        .. code-block:: python
+
           {"N":
-            {"abundance": [0.01,0.99]},
+            {"abundance": [0.01, 0.99]},
             {"mass": [14.00307400443, 15.00010889888]},
           }
     """

--- a/alphabase/protein/fasta.py
+++ b/alphabase/protein/fasta.py
@@ -873,13 +873,12 @@ class SpecLibFasta(SpecLibBase):
         self,
         fasta_files: list,
     ):
-        """
-        Import and process a fasta file or a list of fasta files.
+        """Import and process a fasta file or a list of fasta files.
+
         It includes 3 steps:
 
-        1. Digest and get peptide sequences, it uses `self.get_peptides_from_...()`
-        2. Process the peptides including add modifications,
-        it uses :meth:`process_from_naked_peptide_seqs()`.
+            1. Digest and get peptide sequences, it uses `self.get_peptides_from_...()`
+            2. Process the peptides including add modifications, it uses :meth:`process_from_naked_peptide_seqs()`.
 
         Parameters
         ----------

--- a/alphabase/psm_reader/alphapept_reader.py
+++ b/alphabase/psm_reader/alphapept_reader.py
@@ -89,5 +89,5 @@ class AlphaPeptReader(PSMReaderBase):
 
 
 def register_readers() -> None:
-    """Register readers for AlphaPept's *.ms_data.hdf files."""
+    """Register readers for AlphaPept's .ms_data.hdf files."""
     psm_reader_provider.register_reader("alphapept", AlphaPeptReader)

--- a/alphabase/psm_reader/alphapept_reader.py
+++ b/alphabase/psm_reader/alphapept_reader.py
@@ -49,7 +49,7 @@ def parse_ap(precursor: str) -> Tuple[str, str, str, str, int]:
 
 
 class AlphaPeptReader(PSMReaderBase):
-    """Reader for AlphaPept's *.ms_data.hdf files."""
+    """Reader for AlphaPept's .ms_data.hdf files."""
 
     _reader_type = "alphapept"
 

--- a/alphabase/psm_reader/alphapept_reader.py
+++ b/alphabase/psm_reader/alphapept_reader.py
@@ -1,4 +1,4 @@
-"""Reader for AlphaPept's *.ms_data.hdf files."""
+"""Reader for AlphaPept's .ms_data.hdf files."""
 
 from pathlib import Path
 from typing import Tuple

--- a/alphabase/psm_reader/pfind_reader.py
+++ b/alphabase/psm_reader/pfind_reader.py
@@ -94,7 +94,7 @@ def parse_pfind_protein(protein: str, *, keep_reverse: bool = True) -> str:
 
 
 class pFindReader(PSMReaderBase):  # noqa: N801 name `pFindReader` should use CapWords convention TODO: used by peptdeep, alpharaw
-    """Reader for pFind's *.txt files."""
+    """Reader for pFind's .txt files."""
 
     _reader_type = "pfind"
 

--- a/alphabase/psm_reader/psm_reader.py
+++ b/alphabase/psm_reader/psm_reader.py
@@ -65,7 +65,7 @@ class PSMReaderBase(ABC):
             the value could be the column name or a list of column names
             in other engine's result, for example:
 
-            Example::
+            .. code-block:: python
 
                 columns_mapping = {
                     'sequence': 'NakedSequence',
@@ -84,7 +84,7 @@ class PSMReaderBase(ABC):
             The dict values can be
             either str or list, for exaplme:
 
-            Example::
+            .. code-block:: python
 
                 modification_mapping = {
                     'Oxidation@M': 'Oxidation (M)', # str

--- a/alphabase/psm_reader/psm_reader.py
+++ b/alphabase/psm_reader/psm_reader.py
@@ -64,13 +64,15 @@ class PSMReaderBase(ABC):
             The key of the column_mapping is alphabase's column name, and
             the value could be the column name or a list of column names
             in other engine's result, for example:
-            ```
-            columns_mapping = {
-                'sequence': 'NakedSequence',
-                'charge': 'Charge',
-                'proteins':['Proteins','UniprotIDs'] # list, this reader will automatically detect all of them.
-            }
-            ```
+
+            Example::
+
+                columns_mapping = {
+                    'sequence': 'NakedSequence',
+                    'charge': 'Charge',
+                    'proteins':['Proteins','UniprotIDs'] # list, this reader will automatically detect all of them.
+                }
+
             The first column name in the list will be mapped to the harmonized column names, the rest will be ignored.
             Defaults to None.
 
@@ -81,12 +83,14 @@ class PSMReaderBase(ABC):
             (see :data:`psm_reader_yaml`).
             The dict values can be
             either str or list, for exaplme:
-            ```
-            modification_mapping = {
-            'Oxidation@M': 'Oxidation (M)', # str
-            'Phospho@S': ['S(Phospho (STY))','S(ph)','pS'], # list, this reader will automatically detect all of them.
-            }
-            ```
+
+            Example::
+
+                modification_mapping = {
+                    'Oxidation@M': 'Oxidation (M)', # str
+                    'Phospho@S': ['S(Phospho (STY))','S(ph)','pS'], # list, this reader will automatically detect all of them.
+                }
+
             Defaults to None.
 
         fdr : float, optional

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,6 +80,9 @@ def linkcode_resolve(domain, info):
     except TypeError:
         # e.g. object is a typing.Union
         return None
+    except OSError:
+        # Ignore OSError: could not get source code
+        return None
     file = os.path.relpath(file, os.path.abspath(".."))
     if not file.startswith("alphabase"):
         # e.g. object is a typing.NewType

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,8 +25,4 @@ Table of Contents
 
    api
 
-   ..
-
-      contributing
-
    references


### PR DESCRIPTION
Fixes build error in docs and multiple inconsistencies

## Build error 
Current doc build fails as `linkcode_resolve`  in `docs/conf.py` does not handle `OSError` from `inspect.py`. See also here: https://github.com/ipython/ipython/issues/14057

## Inconsistencies 
Fixes multiple warnings raised by sphinx and reformats docstrings accordingly (small fixes)

- Removes wildcard indicators (*) as they are interpreted as start of an emphasis (`*.txt` -> `.txt`)
- Fix intendation