### PR TITLE
AlphaPept Protein Group Reader

### DIFF
--- a/alphabase/constants/_const.py
+++ b/alphabase/constants/_const.py
@@ -6,6 +6,7 @@ from alphabase.yaml_utils import load_yaml
 
 CONST_FILE_FOLDER = os.path.join(os.path.dirname(__file__), "const_files")
 PSM_READER_YAML_FILE_NAME = "psm_reader.yaml"
+PG_READER_YAML_FILE_NAME = "pg_reader.yaml"
 
 common_const_dict: dict = load_yaml(
     os.path.join(CONST_FILE_FOLDER, "common_constants.yaml")

--- a/alphabase/constants/const_files/pg_reader.yaml
+++ b/alphabase/constants/const_files/pg_reader.yaml
@@ -18,5 +18,5 @@
 alphadia:
   reader_type: "alphadia"
   column_mapping:
-    proteins: "pg"
+    uniprot_ids: "pg"
   measurement_regex: null # all remaining columns are sample columns

--- a/alphabase/constants/const_files/pg_reader.yaml
+++ b/alphabase/constants/const_files/pg_reader.yaml
@@ -12,6 +12,7 @@
 #   # Default regular expression to match the sample columns (e.g. "LFQ$" to match `xxx_LFQ` but not `xxx`)
 #   # If null, selects all columns in the dataframe that are not values in `column_mapping`
 #   measurement_regex: null
+#   TODO: add drop_columns: list[str]
 
 # Based on version 1.10.4
 # https://alphadia.readthedocs.io/en/latest/methods/output-format.html#pg-matrix-tsv
@@ -20,3 +21,15 @@ alphadia:
   column_mapping:
     uniprot_ids: "pg"
   measurement_regex: null # all remaining columns are sample columns
+
+# Based on DIANN version 1.8.1
+diann:
+  reader_type: "diann"
+  column_mapping:
+    "proteins": "Protein.Names" # see also psm_reader.yaml * **Protein.Names** names (UniProt names) of the proteins in the Protein.Group after protein inference
+    "uniprot_ids": "Protein.Group" # Protein.Ids lists all sequence identifiers associated with the peptide. see also psm_reader.yaml
+    "genes": "Genes" # see also psm_reader.yaml
+    # TODO: Drop columns `protein_candidates` and `deescription` as they are confusing and do not add valuable information
+    "protein_candidates": "Protein.Ids" # All proteins that possibly match the precursor before protein inference
+    "description": "First.Protein.Description" # Full description of first protein in Protein.Group
+  measurement_regex: null

--- a/alphabase/constants/const_files/pg_reader.yaml
+++ b/alphabase/constants/const_files/pg_reader.yaml
@@ -1,3 +1,18 @@
+# ## Example configuration
+# example:
+#   # reader_type: str
+#   # (name as defined in the PGReader: alphabase.pg_reader.pg_reader.PGReaderBase attribute `_reader_type`)
+#   reader_type: "name"
+#   # column_mapping: dict[str, str]
+#   # Mapping between standardized columns and search engine-specific columns
+#   # Standardized columns must be defined in `alphabase.pg_reader.keys.PGCols`
+#   column_mapping:
+#     proteins: "pg"
+#   # measurement_regex: str | null
+#   # Default regular expression to match the sample columns (e.g. "LFQ$" to match `xxx_LFQ` but not `xxx`)
+#   # If null, selects all columns in the dataframe that are not values in `column_mapping`
+#   measurement_regex: null
+
 # https://alphadia.readthedocs.io/en/latest/methods/output-format.html#pg-matrix-tsv
 alphadia:
   reader_type: "alphadia"

--- a/alphabase/constants/const_files/pg_reader.yaml
+++ b/alphabase/constants/const_files/pg_reader.yaml
@@ -33,3 +33,19 @@ diann:
     "protein_candidates": "Protein.Ids" # All proteins that possibly match the precursor before protein inference
     "description": "First.Protein.Description" # Full description of first protein in Protein.Group
   measurement_regex: null
+
+
+# Based on alphapept 0.5.6
+alphapept:
+  reader_type: "alphapept"
+  # Column mapping is empty
+  # Mapping is performed by _pre_process function so these are identity transforms
+  # "proteins": "proteins"
+  # "uniprot_ids": "uniprot_ids"
+  # "ensembl_ids": "ensembl_ids"
+  # "source_db": "source_db"
+  # "is_decoy": "is_decoy"
+  column_mapping: {}
+  # Match raw intensities per default.
+  # Match everything at the start but not a trailing LFQ
+  measurement_regex: "^.*(?<!_LFQ)$"

--- a/alphabase/constants/const_files/pg_reader.yaml
+++ b/alphabase/constants/const_files/pg_reader.yaml
@@ -13,6 +13,7 @@
 #   # If null, selects all columns in the dataframe that are not values in `column_mapping`
 #   measurement_regex: null
 
+# Based on version 1.10.4
 # https://alphadia.readthedocs.io/en/latest/methods/output-format.html#pg-matrix-tsv
 alphadia:
   reader_type: "alphadia"

--- a/alphabase/constants/const_files/pg_reader.yaml
+++ b/alphabase/constants/const_files/pg_reader.yaml
@@ -1,0 +1,6 @@
+# https://alphadia.readthedocs.io/en/latest/methods/output-format.html#pg-matrix-tsv
+alphadia:
+  reader_type: "alphadia"
+  column_mapping:
+    proteins: "pg"
+  measurement_regex: null # all remaining columns are sample columns

--- a/alphabase/pg_reader/__init__.py
+++ b/alphabase/pg_reader/__init__.py
@@ -1,5 +1,11 @@
 from .alphadia_pg_reader import AlphaDiaPGReader
+from .alphapept_pg_reader import AlphaPeptPGReader
 from .diann_pg_reader import DiannPGReader
 from .pg_reader import pg_reader_provider
 
-__all__ = ["pg_reader_provider", "AlphaDiaPGReader", "DiannPGReader"]
+__all__ = [
+    "pg_reader_provider",
+    "AlphaDiaPGReader",
+    "DiannPGReader",
+    "AlphaPeptPGReader",
+]

--- a/alphabase/pg_reader/__init__.py
+++ b/alphabase/pg_reader/__init__.py
@@ -1,4 +1,5 @@
 from .alphadia_pg_reader import AlphaDiaPGReader
+from .diann_pg_reader import DiannPGReader
 from .pg_reader import pg_reader_provider
 
-__all__ = ["pg_reader_provider", "AlphaDiaPGReader"]
+__all__ = ["pg_reader_provider", "AlphaDiaPGReader", "DiannPGReader"]

--- a/alphabase/pg_reader/__init__.py
+++ b/alphabase/pg_reader/__init__.py
@@ -1,0 +1,4 @@
+from .alphadia_pg_reader import AlphaDiaPGReader
+from .pg_reader import pg_reader_provider
+
+__all__ = ["pg_reader_provider", "AlphaDiaPGReader"]

--- a/alphabase/pg_reader/alphadia_pg_reader.py
+++ b/alphabase/pg_reader/alphadia_pg_reader.py
@@ -4,7 +4,7 @@ from .pg_reader import PGReaderBase, pg_reader_provider
 
 
 class AlphaDiaPGReader(PGReaderBase):
-    """Reader for proteing group matrices from the alphaDIA search engine."""
+    """Reader for protein group matrices from the alphaDIA search engine."""
 
     _reader_type = "alphadia"
 

--- a/alphabase/pg_reader/alphadia_pg_reader.py
+++ b/alphabase/pg_reader/alphadia_pg_reader.py
@@ -1,0 +1,12 @@
+"""AlphaDIA protein group reader."""
+
+from .pg_reader import PGReaderBase, pg_reader_provider
+
+
+class AlphaDiaPGReader(PGReaderBase):
+    """Reader for proteing group matrices from the alphaDIA search engine."""
+
+    _reader_type = "alphadia"
+
+
+pg_reader_provider.register_reader("alphadia", reader_class=AlphaDiaPGReader)

--- a/alphabase/pg_reader/alphapept_pg_reader.py
+++ b/alphabase/pg_reader/alphapept_pg_reader.py
@@ -135,19 +135,17 @@ class AlphaPeptPGReader(PGReaderBase):
         for entry in protein_entries:
             # Decoys
             # Identify decoys and remove decoy prefix if present
-            entry_is_decoy = bool(decoy_pattern.match(identifier))
-
-            if entry_is_decoy:
-                identifier = re.sub(decoy_pattern, "", identifier)
-
+            entry_is_decoy = bool(decoy_pattern.search(entry))
             is_decoy.append(entry_is_decoy)
 
             # Check for ENSEMBL format (ENSEMBL:IDENTIFIER)
-            if re.match(ensembl_pattern, entry):
+            if re.search(ensembl_pattern, entry):
                 source_db.append("ENSEMBL")
 
                 # Remove "ENSEMBL:" prefix
-                ensembl_ids.append(re.sub(ensembl_pattern, entry, ""))
+                uniprot_ids.append("na")
+                proteins.append("na")
+                ensembl_ids.append(re.sub(ensembl_pattern, "", entry))
 
             # Check if entry contains pipe separators (UniProt format)
             # Options:
@@ -162,16 +160,19 @@ class AlphaPeptPGReader(PGReaderBase):
                     source_db.append(parts[0])
                     uniprot_ids.append(parts[1])
                     proteins.append(parts[2])
+                    ensembl_ids.append("na")
                 else:
                     # Handle unexpected format
                     source_db.append("na")
                     uniprot_ids.append("na")
                     proteins.append(entry)
+                    ensembl_ids.append("na")
             else:
                 # No pipes or ENSEMBL prefix, assume it's just a UniProt ID
                 uniprot_ids.append(entry)
                 source_db.append("na")
                 proteins.append("na")
+                ensembl_ids.append("na")
 
         # Join with semicolons or use "na" if empty
         source_db_str = ";".join(source_db) if source_db else "na"

--- a/alphabase/pg_reader/alphapept_pg_reader.py
+++ b/alphabase/pg_reader/alphapept_pg_reader.py
@@ -78,7 +78,7 @@ class AlphaPeptPGReader(PGReaderBase):
 
         return df
 
-    def _parse_alphapept_index(self, identifier: pd.Index) -> dict[str, str]:
+    def _parse_alphapept_index(self, identifier: str) -> dict[str, str]:
         """Parse protein identifier from AlphaPept protein group table.
 
         Parameters

--- a/alphabase/pg_reader/alphapept_pg_reader.py
+++ b/alphabase/pg_reader/alphapept_pg_reader.py
@@ -117,7 +117,7 @@ class AlphaPeptPGReader(PGReaderBase):
             {"source_db": "ENSEMBL;sp", "uniprot_ids": "P35520", "ensembl_ids": "ENSBTAP00000024146", "proteins": "CBS_HUMAN", "is_decoy": False}
 
             # REV__sp|Q13085|ACACA_HUMAN
-            {"source_db": "sp", "uniprot_ids": "Q13085", "ensembl_ids": "na", "proteins": "ACACA_HUMAN", "is_decoy": True}
+            {"source_db": "REV__sp", "uniprot_ids": "Q13085", "ensembl_ids": "na", "proteins": "ACACA_HUMAN", "is_decoy": True}
 
         """
         decoy_pattern = re.compile(self._DECOY_REGEX)

--- a/alphabase/pg_reader/alphapept_pg_reader.py
+++ b/alphabase/pg_reader/alphapept_pg_reader.py
@@ -13,12 +13,16 @@ class AlphaPeptPGReader(PGReaderBase):
 
     _reader_type: str = "alphapept"
 
+    # Report file settings (delimiter + index column)
     _FILE_DELIMITER: str = ","
     _INDEX_COL: str = 0
 
+    # Feature settings
     # Decoys are prefixed with REV__ in alphapept
     _DECOY_REGEX: str = "^REV__"
+    # Ensembl IDs are identified with a ENSEMBL prefix
     _ENSEMBL_REGEX: str = "^ENSEMBL:"
+    # The expected length of fasta headers is 3 (sp|Uniprot ID|Uniprot Name)
     _FASTA_HEADER_DEFAULT_LENGTH: int = 3
 
     def _load_file(self, file_path: str) -> pd.DataFrame:

--- a/alphabase/pg_reader/alphapept_pg_reader.py
+++ b/alphabase/pg_reader/alphapept_pg_reader.py
@@ -1,0 +1,188 @@
+"""AlphaPept protein group reader."""
+
+import re
+
+import pandas as pd
+
+from .keys import PGCols
+from .pg_reader import PGReaderBase, pg_reader_provider
+
+
+class AlphaPeptPGReader(PGReaderBase):
+    """Reader for protein group matrices from the alphapept search engine."""
+
+    _reader_type: str = "alphapept"
+
+    _FILE_DELIMITER: str = ","
+    _INDEX_COL: str = 0
+
+    # Decoys are prefixed with REV__ in alphapept
+    _DECOY_REGEX: str = "^REV__"
+    _ENSEMBL_REGEX: str = "^ENSEMBL:"
+    _FASTA_HEADER_DEFAULT_LENGTH: int = 3
+
+    def _load_file(self, file_path: str) -> pd.DataFrame:
+        """Load protein group (PG) file from alphapept into a dataframe.
+
+        Parameters
+        ----------
+        file_path
+            File path, must be an alphapept `.csv` proteing roup report.
+
+        Returns
+        -------
+        :class:`pd.DataFrame`
+            Protein group matrix
+
+        """
+        # alphapept does not name its feature index column, i.e. its not possible to use the standard
+        # column mapping procedure
+        # The easiest way is to overwrite the `_load_file` method and set the feature column directly as index
+        return pd.read_csv(
+            file_path,
+            sep=self._FILE_DELIMITER,
+            keep_default_na=False,
+            index_col=self._INDEX_COL,
+        )
+
+    def _pre_process(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Preprocess of alphapept protein group report and return modified copy of the dataframe.
+
+        Parameters
+        ----------
+        df
+            alphapept protein group report.
+
+        Returns
+        -------
+        :class:`pd.DataFrame`
+            Modified copy of protein group report with parsed index. The index contains the levels
+                - proteins: str
+                - uniprot_ids: str
+                - ensembl_ids: str
+                - source_db: str
+                - is_decoy: bool
+
+        """
+        df = df.copy()
+        # Parse index
+        parsed_index: list[dict[str, str]] = list(
+            df.index.map(lambda idx: self._parse_alphapept_index(idx))
+        )
+
+        df.index = pd.MultiIndex.from_frame(pd.DataFrame(parsed_index))
+
+        return df
+
+    def _parse_alphapept_index(self, identifier: pd.Index) -> dict[str, str]:
+        """Parse protein identifier from AlphaPept protein group table.
+
+        Parameters
+        ----------
+        identifier : str
+            Protein identifier string from AlphaPept
+
+        Returns
+        -------
+        dict
+            Dictionary with parsed components:
+            - proteins: str, semicolon-separated protein names or "na"
+            - uniprot_ids: str, semicolon-separated UniProt IDs or "na"
+            - ensembl_ids: str, semicolon-separated ENSEMBL IDs or "na"
+            - source_db: str, semicolon-separated data sources or "na"
+            - is_decoy: bool, True if identifier starts with "REV__"
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            # sp|Q9NQT4|EXOS5_HUMAN
+            {"source_db": "sp", "uniprot_ids": "Q9NQT4", "ensembl_ids": "na", "proteins": "EXOS5_HUMAN", "is_decoy": False}
+
+            # Q0IIK2
+            {"source_db": "na", "uniprot_ids": "Q0IIK2", "ensembl_ids": "na", "proteins": "na", "is_decoy": False}
+
+            # "sp|Q9H2K8|TAOK3_HUMAN,sp|Q7L7X3|TAOK1_HUMAN"
+            {"source_db": "sp;sp", "uniprot_ids": "Q9H2K8;Q7L7X3", "ensembl_ids": "na;na", "proteins": "TAOK3_HUMAN;TAOK1_HUMAN", "is_decoy": False}
+
+            # ENSEMBL:ENSBTAP00000024146
+            {"source_db": "ENSEMBL", "uniprot_ids": "na", "ensembl_ids": "ENSBTAP00000024146", "proteins": "na", "is_decoy": False}
+
+            # ENSEMBL:ENSBTAP00000024146,sp|P35520|CBS_HUMAN
+            {"source_db": "ENSEMBL;sp", "uniprot_ids": "P35520", "ensembl_ids": "ENSBTAP00000024146", "proteins": "CBS_HUMAN", "is_decoy": False}
+
+            # REV__sp|Q13085|ACACA_HUMAN
+            {"source_db": "sp", "uniprot_ids": "Q13085", "ensembl_ids": "na", "proteins": "ACACA_HUMAN", "is_decoy": True}
+
+        """
+        decoy_pattern = re.compile(self._DECOY_REGEX)
+        ensembl_pattern = re.compile(self._ENSEMBL_REGEX)
+
+        # Multiple proteins are separted by comma
+        protein_entries = identifier.split(",")
+
+        source_db: list[str] = []
+        uniprot_ids: list[str] = []
+        ensembl_ids: list[str] = []
+        proteins: list[str] = []
+        is_decoy: list[bool] = []
+
+        for entry in protein_entries:
+            # Decoys
+            # Identify decoys and remove decoy prefix if present
+            entry_is_decoy = bool(decoy_pattern.match(identifier))
+
+            if entry_is_decoy:
+                identifier = re.sub(decoy_pattern, "", identifier)
+
+            is_decoy.append(entry_is_decoy)
+
+            # Check for ENSEMBL format (ENSEMBL:IDENTIFIER)
+            if re.match(ensembl_pattern, entry):
+                source_db.append("ENSEMBL")
+
+                # Remove "ENSEMBL:" prefix
+                ensembl_ids.append(re.sub(ensembl_pattern, entry, ""))
+
+            # Check if entry contains pipe separators (UniProt format)
+            # Options:
+            # sp|Q9H2K8|TAOK3_HUMAN
+            # Q9H2K8
+
+            # TODO: How to handle REV sequences here?
+            # Currently they are only marked by the DECOY_INDICATOR flag, but should the individual identifiers be flagged as well?
+            elif "|" in entry:
+                parts = entry.split("|")
+                if len(parts) == self._FASTA_HEADER_DEFAULT_LENGTH:
+                    source_db.append(parts[0])
+                    uniprot_ids.append(parts[1])
+                    proteins.append(parts[2])
+                else:
+                    # Handle unexpected format
+                    source_db.append("na")
+                    uniprot_ids.append("na")
+                    proteins.append(entry)
+            else:
+                # No pipes or ENSEMBL prefix, assume it's just a UniProt ID
+                uniprot_ids.append(entry)
+                source_db.append("na")
+                proteins.append("na")
+
+        # Join with semicolons or use "na" if empty
+        source_db_str = ";".join(source_db) if source_db else "na"
+        uniprot_ids_str = ";".join(uniprot_ids) if uniprot_ids else "na"
+        ensembl_ids_str = ";".join(ensembl_ids) if ensembl_ids else "na"
+        proteins_str = ";".join(proteins) if proteins else "na"
+        is_decoy = any(is_decoy)
+
+        return {
+            PGCols.PROTEINS: proteins_str,
+            PGCols.UNIPROT_IDS: uniprot_ids_str,
+            PGCols.ENSEMBL_IDS: ensembl_ids_str,
+            PGCols.SOURCE_DB: source_db_str,
+            PGCols.DECOY_INDICATOR: is_decoy,
+        }
+
+
+pg_reader_provider.register_reader("alphapept", reader_class=AlphaPeptPGReader)

--- a/alphabase/pg_reader/alphapept_pg_reader.py
+++ b/alphabase/pg_reader/alphapept_pg_reader.py
@@ -9,7 +9,75 @@ from .pg_reader import PGReaderBase, pg_reader_provider
 
 
 class AlphaPeptPGReader(PGReaderBase):
-    """Reader for protein group matrices from the alphapept search engine."""
+    """Reader for protein group matrices from the alphapept search engine.
+
+    Per default, the reader will read raw intensities from the protein group matrix. By passing a
+    suitable regular expression, it is also possible to extract LFQ corrected intensities from the
+    reader.
+
+    Example:
+    -------
+    AlphaPept protein group matrices contain both raw intensities and LFQ-corrected intensities.
+    The LFQ-corrected intensities are marked by an `_LFQ` suffix.
+
+    .. code-block:: python
+
+        import os
+        import tmpfile
+        from alphabase.tools.data_downloader import DataShareDownloader
+        from alphabase.pg_reader import AlphaPeptPGReader
+
+
+        # Get example data
+        URL = "https://datashare.biochem.mpg.de/s/6G6KHJqwcRPQiOO"
+        download_dir = tempfile.mkdtemp()
+
+        download_path = DataShareDownloader(url=URL, output_dir=download_dir).download()
+
+
+    Per default, the reader will return the raw intensities
+
+    .. code-block:: python
+
+        # Get raw intensities
+        reader = AlphaPeptPGReader()
+        results = reader.import_file(download_path)
+        results.index.names
+        > FrozenList(['proteins', 'uniprot_ids', 'ensembl_ids', 'source_db', 'is_decoy'])
+        results.columns
+        > Index(['A', 'B'], dtype='object')
+
+    To read the LFQ values, pass the regex `LFQ` to the reader
+
+    .. code-block:: python
+
+        # Get raw intensities
+        reader = AlphaPeptPGReader(measurement_regex="LFQ")
+        results = reader.import_file(download_path)
+        results.index.names
+        > FrozenList(['proteins', 'uniprot_ids', 'ensembl_ids', 'source_db', 'is_decoy'])
+        results.columns
+        > Index(['A_LFQ', 'B_LFQ'], dtype='object')
+
+
+    To get all values via a custom regex, pass `.*` that matches any column name.
+
+    .. code-block:: python
+
+        reader = AlphaPeptPGReader(measurement_regex=".*")
+        results.columns
+        > Index(['A_LFQ', 'B_LFQ', 'A', 'B'], dtype='object')
+
+
+    .. code-block:: python
+
+        # Get rid of data
+        os.rmdir(download_dir)
+
+
+
+
+    """
 
     _reader_type: str = "alphapept"
 

--- a/alphabase/pg_reader/diann_pg_reader.py
+++ b/alphabase/pg_reader/diann_pg_reader.py
@@ -1,0 +1,12 @@
+"""DIANN protein group reader."""
+
+from .pg_reader import PGReaderBase, pg_reader_provider
+
+
+class DiannPGReader(PGReaderBase):
+    """Reader for protein group matrices from the DIANN search engine."""
+
+    _reader_type = "diann"
+
+
+pg_reader_provider.register_reader("diann", reader_class=DiannPGReader)

--- a/alphabase/pg_reader/keys.py
+++ b/alphabase/pg_reader/keys.py
@@ -14,6 +14,9 @@ class PGCols(metaclass=ConstantsClass):
     UNIPROT_IDS
         Uniprot IDs of all proteins in the respective protein group.
         Individual entries are separated by a semicolon in the unified output.
+    ENSEMBL_IDS
+        ENSEMBL IDs of proteins in the respective protein group.
+        Individual entries are separated by a semicolon in the unified output.
     GENES
         Gene names encoding the proteins in the respective protein group. Uses HGNC names for humans.
         Individual entries are separated by a semicolon in the unified output.
@@ -22,12 +25,21 @@ class PGCols(metaclass=ConstantsClass):
         Individual entries are separated by a semicolon in the unified output.
     DESCRIPTION
         Long text description of one or more proteins in the respective protein group.
+    SOURCE_DB
+        Source databases for a specific feature, e.g. Uniprot, Swissprot, Ensembl.
+        Individual entries are separated by a semicolon in the unified output.
+    DECOY_INDICATOR
+        Boolean that indicates that the respective feature is maked as a decoy by the respective
+        search engine.
 
     """
 
     # Minimal columns
     PROTEINS = "proteins"
     UNIPROT_IDS = "uniprot_ids"
+    ENSEMBL_IDS = "ensembl_ids"
     GENES = "genes"
     PROTEIN_CANDIDATES = "protein_candidates"
     DESCRIPTION = "description"
+    SOURCE_DB = "source_db"
+    DECOY_INDICATOR = "is_decoy"

--- a/alphabase/pg_reader/keys.py
+++ b/alphabase/pg_reader/keys.py
@@ -4,7 +4,19 @@ from alphabase.psm_reader.keys import ConstantsClass
 
 
 class PGCols(metaclass=ConstantsClass):
-    """Standardized keys for PG readers."""
+    """Standardized keys for PG readers.
+
+    Attributes
+    ----------
+    PROTEINS
+        Uniprot names of proteins in the respective protein group.
+        Individual entries are separated by a semicolon in the unified output.
+    UNIPROT_IDS
+        Uniprot IDs of all proteins in the respective protein group.
+        Individual entries are separated by a semicolon in the unified output.
+
+    """
 
     # Minimal columns
     PROTEINS = "proteins"
+    UNIPROT_IDS = "uniprot_ids"

--- a/alphabase/pg_reader/keys.py
+++ b/alphabase/pg_reader/keys.py
@@ -1,0 +1,10 @@
+"""Constants for accessing the columns of a PG dataframe."""
+
+from alphabase.psm_reader.keys import ConstantsClass
+
+
+class PGCols(metaclass=ConstantsClass):
+    """Standardized keys for PG readers."""
+
+    # Minimal columns
+    PROTEINS = "proteins"

--- a/alphabase/pg_reader/keys.py
+++ b/alphabase/pg_reader/keys.py
@@ -29,5 +29,5 @@ class PGCols(metaclass=ConstantsClass):
     PROTEINS = "proteins"
     UNIPROT_IDS = "uniprot_ids"
     GENES = "genes"
-    PROTEIN_CANDIATES = "protein_candidates"
+    PROTEIN_CANDIDATES = "protein_candidates"
     DESCRIPTION = "description"

--- a/alphabase/pg_reader/keys.py
+++ b/alphabase/pg_reader/keys.py
@@ -29,5 +29,5 @@ class PGCols(metaclass=ConstantsClass):
     PROTEINS = "proteins"
     UNIPROT_IDS = "uniprot_ids"
     GENES = "genes"
-    PROTEIN_CANDIDATES = "protein_candidates"
+    PROTEIN_CANDIATES = "protein_candidates"
     DESCRIPTION = "description"

--- a/alphabase/pg_reader/keys.py
+++ b/alphabase/pg_reader/keys.py
@@ -14,9 +14,20 @@ class PGCols(metaclass=ConstantsClass):
     UNIPROT_IDS
         Uniprot IDs of all proteins in the respective protein group.
         Individual entries are separated by a semicolon in the unified output.
+    GENES
+        Gene names encoding the proteins in the respective protein group. Uses HGNC names for humans.
+        Individual entries are separated by a semicolon in the unified output.
+    PROTEIN_CANDIDATES
+        Uniprot IDs of all proteins matching a specific precursor before protein inference.
+        Individual entries are separated by a semicolon in the unified output.
+    DESCRIPTION
+        Long text description of one or more proteins in the respective protein group.
 
     """
 
     # Minimal columns
     PROTEINS = "proteins"
     UNIPROT_IDS = "uniprot_ids"
+    GENES = "genes"
+    PROTEIN_CANDIDATES = "protein_candidates"
+    DESCRIPTION = "description"

--- a/alphabase/pg_reader/pg_reader.py
+++ b/alphabase/pg_reader/pg_reader.py
@@ -174,13 +174,13 @@ class PGReaderBase:
         return pd.read_csv(file_path, sep=sep, keep_default_na=False)
 
     def _pre_process(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Preprocess dataframe before standardizing columns and return the updated dataframe."""
+        """Preprocess dataframe before standardizing columns and return an updated copy."""
         return df
 
     def _translate_columns(
         self, df: pd.DataFrame, column_mapping: dict[str, str]
     ) -> pd.DataFrame:
-        """Translate standardized columns in dataframe from other search engines to AlphaBase format and return the updated dataframe."""
+        """Translate standardized columns in dataframe from other search engines to AlphaBase format an updated copy."""
         return df.rename(columns=column_mapping)
 
     def _filter_measurement(
@@ -189,7 +189,7 @@ class PGReaderBase:
         regex: str,
         extra_columns: Optional[Iterable[str]] = None,
     ) -> pd.DataFrame:
-        """Subset :class:`pd.DataFrame` to columns matching a regex plus plus optionally extra columns and return the updated dataframe.
+        """Subset :class:`pd.DataFrame` to columns matching a regex plus plus optionally extra columns an updated copy.
 
         Parameters
         ----------

--- a/alphabase/pg_reader/pg_reader.py
+++ b/alphabase/pg_reader/pg_reader.py
@@ -146,6 +146,7 @@ class PGReaderBase:
                 extra_columns=feature_columns,
             )
 
+        # Keep dataframe index as default if no features are specified in column mapping
         return df.set_index(feature_columns) if len(feature_columns) > 0 else df
 
     def _load_file(self, file_path: str) -> pd.DataFrame:

--- a/alphabase/pg_reader/pg_reader.py
+++ b/alphabase/pg_reader/pg_reader.py
@@ -110,7 +110,7 @@ class PGReaderBase:
         Parameters
         ----------
         file_path: str
-            Absolute path to the file containing pg data
+            Absolute path to the file containing protein group data
 
         Returns
         -------
@@ -174,13 +174,13 @@ class PGReaderBase:
         return pd.read_csv(file_path, sep=sep, keep_default_na=False)
 
     def _pre_process(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Preprocess dataframe before standardizing columns. Per default, returns the unchanged dataframe."""
+        """Preprocess dataframe before standardizing columns and return the updated dataframe."""
         return df
 
     def _translate_columns(
         self, df: pd.DataFrame, column_mapping: dict[str, str]
     ) -> pd.DataFrame:
-        """Translate standardized columns in dataframe from other search engines to AlphaBase format."""
+        """Translate standardized columns in dataframe from other search engines to AlphaBase format and return the updated dataframe."""
         return df.rename(columns=column_mapping)
 
     def _filter_measurement(
@@ -189,7 +189,7 @@ class PGReaderBase:
         regex: str,
         extra_columns: Optional[Iterable[str]] = None,
     ) -> pd.DataFrame:
-        """Subset :class:`pd.DataFrame` to columns matching a regex plus plus optionally extra columns.
+        """Subset :class:`pd.DataFrame` to columns matching a regex plus plus optionally extra columns and return the updated dataframe.
 
         Parameters
         ----------

--- a/alphabase/pg_reader/pg_reader.py
+++ b/alphabase/pg_reader/pg_reader.py
@@ -2,7 +2,7 @@
 
 import re
 import warnings
-from copy import copy
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional, Type
 
@@ -241,7 +241,7 @@ class PGReaderProvider:
         yaml_dict: dict,
     ) -> PGReaderBase:
         """Get a reader by a yaml dict."""
-        return self.get_reader(**copy.deepcopy(yaml_dict))
+        return self.get_reader(**deepcopy(yaml_dict))
 
 
 pg_reader_provider = PGReaderProvider()

--- a/alphabase/pg_reader/pg_reader.py
+++ b/alphabase/pg_reader/pg_reader.py
@@ -210,7 +210,7 @@ class PGReaderBase:
         extra_columns = extra_columns if extra_columns is not None else []
 
         pattern = re.compile(regex)
-        regex_columns = [col for col in df.columns if re.match(pattern, col)]
+        regex_columns = [col for col in df.columns if re.search(pattern, col)]
 
         if len(regex_columns) == 0:
             warnings.warn(f"regex {regex} did not match any columns in the dataframe")

--- a/alphabase/pg_reader/pg_reader.py
+++ b/alphabase/pg_reader/pg_reader.py
@@ -172,7 +172,10 @@ class PGReaderBase:
         return df.rename(columns=column_mapping)
 
     def _filter_measurement(
-        self, df: pd.DataFrame, regex: str, extra_columns: Iterable[str] | None = None
+        self,
+        df: pd.DataFrame,
+        regex: str,
+        extra_columns: Optional[Iterable[str]] = None,
     ) -> pd.DataFrame:
         """Subset :class:`pd.DataFrame` to columns matching a regex plus extra columns.
 

--- a/alphabase/pg_reader/pg_reader.py
+++ b/alphabase/pg_reader/pg_reader.py
@@ -89,7 +89,7 @@ class PGReaderBase:
         """Add additional column mappings for the search engine."""
         self.column_mapping = {**self.column_mapping, **column_mapping}
 
-    def import_file(self, filename: str) -> pd.DataFrame:
+    def import_file(self, file_path: str) -> pd.DataFrame:
         """Import a PG matrix and process it to the alphabase convention.
 
         Loads the PG matrix, standardizes feature metadata columns, and filters for the
@@ -97,8 +97,9 @@ class PGReaderBase:
 
         Parameters
         ----------
-        filename: str
-            File path
+        file_path: str
+            Absolute path to the file containing pg data
+
 
         Returns
         -------
@@ -107,7 +108,7 @@ class PGReaderBase:
 
         """
         # Load to dataframe
-        df = self._load_file(filename)
+        df = self._load_file(file_path)
 
         df = self._pre_process(df)
 
@@ -136,13 +137,13 @@ class PGReaderBase:
 
         return df.set_index(feature_columns)
 
-    def _load_file(self, filename: str) -> pd.DataFrame:
+    def _load_file(self, file_path: str) -> pd.DataFrame:
         """Load PG file into a dataframe.
 
         Parameters
         ----------
-        filename
-            Path to file, must be .csv, .tsv, or .hdf
+        file_path
+            File path, must be .csv, .tsv, or .hdf
 
         Returns
         -------
@@ -155,11 +156,11 @@ class PGReaderBase:
         all supported search engines.
 
         """
-        if Path(filename).suffix == ".hdf":
-            return pd.read_hdf(filename)
+        if Path(file_path).suffix == ".hdf":
+            return pd.read_hdf(file_path)
 
-        sep = _get_delimiter(filename)
-        return pd.read_csv(filename, sep=sep, keep_default_na=False)
+        sep = _get_delimiter(file_path)
+        return pd.read_csv(file_path, sep=sep, keep_default_na=False)
 
     def _pre_process(self, df: pd.DataFrame) -> pd.DataFrame:
         """Preprocess dataframe before standardizing columns. Per default, returns the unchanged dataframe."""

--- a/alphabase/pg_reader/pg_reader.py
+++ b/alphabase/pg_reader/pg_reader.py
@@ -146,7 +146,7 @@ class PGReaderBase:
                 extra_columns=feature_columns,
             )
 
-        return df.set_index(feature_columns)
+        return df.set_index(feature_columns) if len(feature_columns) > 0 else df
 
     def _load_file(self, file_path: str) -> pd.DataFrame:
         """Load protein group (PG) file into a dataframe.

--- a/alphabase/pg_reader/pg_reader.py
+++ b/alphabase/pg_reader/pg_reader.py
@@ -115,7 +115,7 @@ class PGReaderBase:
         Returns
         -------
         :class:`pd.DataFrame`
-            protein group Matrix with feature metadata as index
+            Protein group matrix with feature metadata as index
 
         """
         # Load to dataframe

--- a/alphabase/pg_reader/pg_reader.py
+++ b/alphabase/pg_reader/pg_reader.py
@@ -1,0 +1,250 @@
+"""The base class for all PG readers and the provider for all PG readers."""
+
+import re
+import warnings
+from copy import copy
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional, Type
+
+import pandas as pd
+
+from alphabase.constants._const import CONST_FILE_FOLDER, PG_READER_YAML_FILE_NAME
+from alphabase.psm_reader.utils import get_column_mapping_for_df
+from alphabase.utils import _get_delimiter
+from alphabase.yaml_utils import load_yaml
+
+# see pg_reader.yaml alphabase/constants/const_files/pg_reader.yaml
+
+pg_reader_yaml = load_yaml(Path(CONST_FILE_FOLDER) / PG_READER_YAML_FILE_NAME)
+
+
+_COLUMN_MAPPING = "column_mapping"
+_MEASUREMENT_REGEX = "measurement_regex"
+
+
+class PGReaderBase:
+    """Base class for all PG readers.
+
+    Supports reading of protein groups of five common types:
+        - Type 1 — Minimal: Wide format (~features x samples), with sample names as columns and protein group intensities as values. Example: AlphaDIA.
+        - Type 2 — Multiple Intensity Fields: Wide format with multiple intensity types per sample (e.g., SampleA_LFQ, SampleB_raw). Example: AlphaPept.
+        - Type 3 — Additional Feature Metadata: Similar to Type 1 but includes extra feature columns (e.g., Gene, Description). Example: DIA-NN.
+        - Type 4 — Additional Sample Metadata: Non-standard format.
+        - Type 5 — Combined: Includes both multiple intensity fields and additional feature metadata. Examples: Spectronaut, MZTab, MaxQuant.
+    """
+
+    _reader_type: str
+
+    def __init__(
+        self,
+        *,
+        column_mapping: Optional[dict[str, Any]] = None,
+        measurement_regex: Optional[str] = None,
+    ):
+        """Read PG matrices into the standardized alphabase format.
+
+        Parameters
+        ----------
+        column_mapping
+            A dictionary of mapping alphabase columns (keys) to the corresponding columns in the other
+            search engine (values). If `None` will be loaded from the `column_mapping` key of the respective
+            search engine in `pg_reader.yaml`
+        measurement_regex
+            Regular expression that identifies correct measurement type. Only relevant if PG matrix contains multiple
+            measurement types. For example, alphapept returns the raw protein intensity per sample in column `A` and the
+            LFQ corrected value in `A_LFQ`. If `None` uses all columns.
+
+
+        Attributes
+        ----------
+        column_mapping
+            Dictionary structure mapping alphabase columns (keys) to the corresponding columns in the other
+            search engine (values), see parameters.
+        measurement_regex
+            Regular expression that matches quantity of interest for all samples
+
+        Notes
+        -----
+        Standardizes PG reports to a protein group dataframe (features x samples) in wide format. Contains at least
+            - sample (run) identifier: :att:`pg_reader.keys.PGCols.SAMPLE_NAME` as column index
+            - protein group identifier: :att:`pg_reader.keys.PGCols.protein` as index
+            - protein group intensity: :att:`pg_reader.keys.PGCols.INTENSITY` as values
+
+        Additional feature-level metadata might be available in the index.
+
+        """
+        self.column_mapping = (
+            column_mapping
+            if column_mapping is not None
+            else pg_reader_yaml[self._reader_type][_COLUMN_MAPPING]
+        )
+
+        self.measurement_regex = (
+            measurement_regex
+            if measurement_regex is not None
+            else pg_reader_yaml[self._reader_type][_MEASUREMENT_REGEX]
+        )
+
+    def add_column_mapping(self, column_mapping: Dict) -> None:
+        """Add additional column mappings for the search engine."""
+        self.column_mapping = {**self.column_mapping, **column_mapping}
+
+    def import_file(self, filename: str) -> pd.DataFrame:
+        """Import a PG matrix and process it to the alphabase convention.
+
+        Loads the PG matrix, standardizes feature metadata columns, and filters for the
+        desired measurement type
+
+        Parameters
+        ----------
+        filename: str
+            File path
+
+        Returns
+        -------
+        :class:`pd.DataFrame`
+            Protein Group Matrix with feature metadata as index
+
+        """
+        # Load to dataframe
+        df = self._load_file(filename)
+
+        df = self._pre_process(df)
+
+        if len(df) == 0:
+            return pd.DataFrame()
+
+        # Standardize feature columns
+        # `get_column_mapping_for_df` returns mapping of the form {standardized: search engine-specific}
+        # invert to faciliate mapping
+        # This is possible as the function guarantees to return a 1-1 mapping
+        engine_to_standard = {
+            v: k for k, v in get_column_mapping_for_df(self.column_mapping, df).items()
+        }
+        feature_columns = list(engine_to_standard.values())
+
+        df = self._translate_columns(df, column_mapping=engine_to_standard)
+
+        # Subset to relevant sample columns
+        # For example in alphapept sample vs. sample_LFQ
+        if self.measurement_regex is not None:
+            df = self._filter_measurement(
+                df,
+                regex=self.measurement_regex,
+                extra_columns=feature_columns,
+            )
+
+        return df.set_index(feature_columns)
+
+    def _load_file(self, filename: str) -> pd.DataFrame:
+        """Load PG file into a dataframe.
+
+        Parameters
+        ----------
+        filename
+            Path to file, must be .csv, .tsv, or .hdf
+
+        Returns
+        -------
+        :class:`pd.DataFrame`
+            PG Matrix
+
+        Notes
+        -----
+        Supports comma separated, tab separated, and .hdf files which covers the file types of
+        all supported search engines.
+
+        """
+        if Path(filename).suffix == "hdf":
+            return pd.read_hdf(filename)
+
+        sep = _get_delimiter(filename)
+        return pd.read_csv(filename, sep=sep, keep_default_na=False)
+
+    def _pre_process(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Preprocess dataframe before standardizing columns. Per default, returns the unchanged dataframe."""
+        return df
+
+    def _translate_columns(
+        self, df: pd.DataFrame, column_mapping: dict[str, str]
+    ) -> pd.DataFrame:
+        """Translate standardized columns in dataframe from other search engines to AlphaBase format."""
+        return df.rename(columns=column_mapping)
+
+    def _filter_measurement(
+        self, df: pd.DataFrame, regex: str, extra_columns: Iterable[str] | None = None
+    ) -> pd.DataFrame:
+        """Subset :class:`pd.DataFrame to columns matching a regex plus extra columns.
+
+        Parameters
+        ----------
+        df
+            :class:`pd.DataFrame`
+        regex
+            Regular expression that matches the respective columns
+        extra_columns
+            Keep the specified columns although they do not match the regex
+
+        Returns
+        -------
+        :class:`pd.DataFrame`
+            Filtered dataframe with columns matching `regex` and columns explicitly
+            specified in `keep_columns`.
+
+        """
+        extra_columns = extra_columns if extra_columns is not None else []
+
+        pattern = re.compile(regex)
+        regex_columns = [col for col in df.columns if re.match(pattern, col)]
+
+        if len(regex_columns) == 0:
+            warnings.warn(f"regex {regex} did not match any columns in the dataframe")
+
+        return df[regex_columns + extra_columns]
+
+
+# TODO: Refactor and create base class for PG Reader provider and PSMReaderProvider
+class PGReaderProvider:
+    """A factory class to register and get readers for different PG types."""
+
+    def __init__(self):
+        """Initialize PGReaderProvider."""
+        self.reader_dict: dict[str, Type[PGReaderBase]] = {}
+
+    def register_reader(
+        self, reader_type: str, reader_class: Type[PGReaderBase]
+    ) -> None:
+        """Register a reader by reader_type."""
+        self.reader_dict[reader_type.lower()] = reader_class
+
+    def get_reader(
+        self,
+        reader_type: str,
+        *,
+        column_mapping: Optional[dict] = None,
+        **kwargs,
+    ) -> PGReaderBase:
+        """Get a reader by reader_type."""
+        try:
+            return self.reader_dict[reader_type.lower()](
+                column_mapping=column_mapping,
+                **kwargs,
+            )
+        except KeyError as e:
+            raise KeyError(
+                f"Unknown reader type '{reader_type}'. Available readers: "
+                f"{', '.join(self.reader_dict.keys())}"
+            ) from e
+
+    def get_reader_by_yaml(
+        self,
+        yaml_dict: dict,
+    ) -> PGReaderBase:
+        """Get a reader by a yaml dict."""
+        return self.get_reader(**copy.deepcopy(yaml_dict))
+
+
+pg_reader_provider = PGReaderProvider()
+"""
+A factory :class:`PGReaderProvider` object to register and get readers for different PG types.
+"""

--- a/alphabase/pg_reader/pg_reader.py
+++ b/alphabase/pg_reader/pg_reader.py
@@ -23,14 +23,26 @@ _MEASUREMENT_REGEX = "measurement_regex"
 
 
 class PGReaderBase:
-    """Base class for all PG readers.
+    """Base class for all protein group (PG) readers.
 
-    Supports reading of protein groups of five common types:
-        - Type 1 — Minimal: Wide format (~features x samples), with sample names as columns and protein group intensities as values. Example: AlphaDIA.
-        - Type 2 — Multiple Intensity Fields: Wide format with multiple intensity types per sample (e.g., SampleA_LFQ, SampleB_raw). Example: AlphaPept.
-        - Type 3 — Additional Feature Metadata: Similar to Type 1 but includes extra feature columns (e.g., Gene, Description). Example: DIA-NN.
-        - Type 4 — Additional Sample Metadata: Non-standard format.
-        - Type 5 — Combined: Includes both multiple intensity fields and additional feature metadata. Examples: Spectronaut, MZTab, MaxQuant.
+    Supports reading of protein groups of common types:
+
+    - **Type 1 — Minimal**: A basic features x samples matrix.
+      Only intensity values are stored, with sample names as columns and protein groups as the index.
+      **Example**: AlphaDIA.
+
+    - **Type 2 — Multiple Intensity Fields**: A wide matrix where each sample may appear multiple times
+      with different quantification types (e.g., `SampleA_LFQ`, `SampleB_raw`). Intensity columns are typically
+      identifiable using regular expressions. Only intensity fields are included.
+      **Example**: AlphaPept.
+
+    - **Type 3 — Feature Metadata**: A features x samples matrix with one intensity value per sample,
+      plus additional feature-level metadata columns (e.g., gene names, descriptions).
+      **Example**: DIA-NN.
+
+    - **Type 4 — Combined**: A composite structure including both multiple intensity fields (Type 2)
+      and feature-level metadata (Type 3).
+      **Examples**: Spectronaut, MZTab, MaxQuant.
     """
 
     _reader_type: str
@@ -41,7 +53,7 @@ class PGReaderBase:
         column_mapping: Optional[dict[str, Any]] = None,
         measurement_regex: Optional[str] = None,
     ):
-        """Read PG matrices into the standardized alphabase format.
+        """Read protein group (PG) matrices into the standardized alphabase format.
 
         Parameters
         ----------
@@ -65,7 +77,7 @@ class PGReaderBase:
 
         Notes
         -----
-        Standardizes PG reports to a protein group dataframe (features x samples) in wide format. Contains at least
+        Standardizes protein group reports to a protein group dataframe (features x samples) in wide format. Contains at least
             - sample (run) identifier: :att:`pg_reader.keys.PGCols.SAMPLE_NAME` as column index
             - protein group identifier: :att:`pg_reader.keys.PGCols.protein` as index
             - protein group intensity: :att:`pg_reader.keys.PGCols.INTENSITY` as values
@@ -90,9 +102,9 @@ class PGReaderBase:
         self.column_mapping = {**self.column_mapping, **column_mapping}
 
     def import_file(self, file_path: str) -> pd.DataFrame:
-        """Import a PG matrix and process it to the alphabase convention.
+        """Import a protein group (PG) matrix and process it to the alphabase convention.
 
-        Loads the PG matrix, standardizes feature metadata columns, and filters for the
+        Loads the protein group matrix, standardizes feature metadata columns, and filters for the
         desired measurement type
 
         Parameters
@@ -100,11 +112,10 @@ class PGReaderBase:
         file_path: str
             Absolute path to the file containing pg data
 
-
         Returns
         -------
         :class:`pd.DataFrame`
-            Protein Group Matrix with feature metadata as index
+            protein group Matrix with feature metadata as index
 
         """
         # Load to dataframe
@@ -138,7 +149,7 @@ class PGReaderBase:
         return df.set_index(feature_columns)
 
     def _load_file(self, file_path: str) -> pd.DataFrame:
-        """Load PG file into a dataframe.
+        """Load protein group (PG) file into a dataframe.
 
         Parameters
         ----------
@@ -148,7 +159,7 @@ class PGReaderBase:
         Returns
         -------
         :class:`pd.DataFrame`
-            PG Matrix
+            Protein group matrix
 
         Notes
         -----
@@ -178,7 +189,7 @@ class PGReaderBase:
         regex: str,
         extra_columns: Optional[Iterable[str]] = None,
     ) -> pd.DataFrame:
-        """Subset :class:`pd.DataFrame` to columns matching a regex plus extra columns.
+        """Subset :class:`pd.DataFrame` to columns matching a regex plus plus optionally extra columns.
 
         Parameters
         ----------
@@ -187,7 +198,7 @@ class PGReaderBase:
         regex
             Regular expression that matches the respective columns
         extra_columns
-            Keep the specified columns although they do not match the regex
+            Keep the specified columns although they do not match the regex, defaults to `None`.
 
         Returns
         -------
@@ -209,7 +220,7 @@ class PGReaderBase:
 
 # TODO: Refactor and create base class for PG Reader provider and PSMReaderProvider
 class PGReaderProvider:
-    """A factory class to register and get readers for different PG types."""
+    """A factory class to register and get readers for different protein group report types."""
 
     def __init__(self):
         """Initialize PGReaderProvider."""
@@ -250,5 +261,5 @@ class PGReaderProvider:
 
 pg_reader_provider = PGReaderProvider()
 """
-A factory :class:`PGReaderProvider` object to register and get readers for different PG types.
+A factory :class:`PGReaderProvider` object to register and get readers for different protein group report types.
 """

--- a/alphabase/pg_reader/pg_reader.py
+++ b/alphabase/pg_reader/pg_reader.py
@@ -155,7 +155,7 @@ class PGReaderBase:
         all supported search engines.
 
         """
-        if Path(filename).suffix == "hdf":
+        if Path(filename).suffix == ".hdf":
             return pd.read_hdf(filename)
 
         sep = _get_delimiter(filename)
@@ -174,7 +174,7 @@ class PGReaderBase:
     def _filter_measurement(
         self, df: pd.DataFrame, regex: str, extra_columns: Iterable[str] | None = None
     ) -> pd.DataFrame:
-        """Subset :class:`pd.DataFrame to columns matching a regex plus extra columns.
+        """Subset :class:`pd.DataFrame` to columns matching a regex plus extra columns.
 
         Parameters
         ----------

--- a/alphabase/pg_reader/pg_reader.py
+++ b/alphabase/pg_reader/pg_reader.py
@@ -180,7 +180,7 @@ class PGReaderBase:
     def _translate_columns(
         self, df: pd.DataFrame, column_mapping: dict[str, str]
     ) -> pd.DataFrame:
-        """Translate standardized columns in dataframe from other search engines to AlphaBase format an updated copy."""
+        """Translate standardized columns in dataframe from other search engines to AlphaBase format and return an updated copy."""
         return df.rename(columns=column_mapping)
 
     def _filter_measurement(
@@ -189,7 +189,7 @@ class PGReaderBase:
         regex: str,
         extra_columns: Optional[Iterable[str]] = None,
     ) -> pd.DataFrame:
-        """Subset :class:`pd.DataFrame` to columns matching a regex plus plus optionally extra columns an updated copy.
+        """Subset :class:`pd.DataFrame` to columns matching a regex plus optionally extra columns and return an updated copy.
 
         Parameters
         ----------

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,20 @@
+"""Shared logic for integration tests."""
+
+import os
+from typing import Generator
+
+import pandas as pd
+import pytest
+
+from alphabase.tools.data_downloader import DataShareDownloader
+
+
+@pytest.fixture(scope="function")
+def example_alphadia_tsv(tmp_path) -> Generator[pd.DataFrame, None, None]:
+    """Get and parse real alphadia PG report matrix."""
+    URL = "https://datashare.biochem.mpg.de/s/cN1tmElfgKOe1cW"
+
+    download_path = DataShareDownloader(url=URL, output_dir=tmp_path).download()
+    yield download_path
+
+    os.remove(download_path)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,3 +23,12 @@ def example_diann_tsv(tmp_path) -> Path:
 
     download_path = DataShareDownloader(url=URL, output_dir=tmp_path).download()
     return download_path
+
+
+@pytest.fixture(scope="function")
+def example_alphapept_csv(tmp_path) -> Path:
+    """Get and parse real alphapept protein group report matrix."""
+    URL = "https://datashare.biochem.mpg.de/s/6G6KHJqwcRPQiOO"
+
+    download_path = DataShareDownloader(url=URL, output_dir=tmp_path).download()
+    return download_path

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,20 +1,16 @@
 """Shared logic for integration tests."""
 
-import os
-from typing import Generator
+from pathlib import Path
 
-import pandas as pd
 import pytest
 
 from alphabase.tools.data_downloader import DataShareDownloader
 
 
 @pytest.fixture(scope="function")
-def example_alphadia_tsv(tmp_path) -> Generator[pd.DataFrame, None, None]:
+def example_alphadia_tsv(tmp_path) -> Path:
     """Get and parse real alphadia PG report matrix."""
     URL = "https://datashare.biochem.mpg.de/s/cN1tmElfgKOe1cW"
 
     download_path = DataShareDownloader(url=URL, output_dir=tmp_path).download()
-    yield download_path
-
-    os.remove(download_path)
+    return download_path

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,3 +14,12 @@ def example_alphadia_tsv(tmp_path) -> Path:
 
     download_path = DataShareDownloader(url=URL, output_dir=tmp_path).download()
     return download_path
+
+
+@pytest.fixture(scope="function")
+def example_diann_tsv(tmp_path) -> Path:
+    """Get and parse real alphadia PG report matrix."""
+    URL = "https://datashare.biochem.mpg.de/s/R7GYhwArBO2NS9J"
+
+    download_path = DataShareDownloader(url=URL, output_dir=tmp_path).download()
+    return download_path

--- a/tests/integration/test_pg_reader_provider.py
+++ b/tests/integration/test_pg_reader_provider.py
@@ -1,6 +1,6 @@
 """Integration tests for protein group reader provider."""
 
-from alphabase.pg_reader import AlphaDiaPGReader, pg_reader_provider
+from alphabase.pg_reader import AlphaDiaPGReader, DiannPGReader, pg_reader_provider
 from alphabase.pg_reader.keys import PGCols
 
 
@@ -19,3 +19,26 @@ class TestAlphaDiaPGReaderProvider:
 
         assert result_df.shape == (9364, 6)
         assert result_df.index.name == PGCols.UNIPROT_IDS
+
+
+class TestDiannPGReaderProvider:
+    def test_reader_provider(self) -> None:
+        """Test whether reader provider initializes alphadia PG reader correctly."""
+        reader = pg_reader_provider.get_reader("diann")
+
+        assert isinstance(reader, DiannPGReader)
+
+    def test_reader_provider_import(self, example_diann_tsv: str) -> None:
+        """Test if diann protein group report import works via `pg_reader_provider`"""
+        reader = pg_reader_provider.get_reader("diann")
+
+        result_df = reader.import_file(example_diann_tsv)
+
+        assert result_df.shape == (10, 20)
+        assert result_df.index.names == [
+            PGCols.PROTEINS,
+            PGCols.UNIPROT_IDS,
+            PGCols.GENES,
+            PGCols.PROTEIN_CANDIDATES,
+            PGCols.DESCRIPTION,
+        ]

--- a/tests/integration/test_pg_reader_provider.py
+++ b/tests/integration/test_pg_reader_provider.py
@@ -18,4 +18,4 @@ class TestAlphaDiaPGReaderProvider:
         result_df = reader.import_file(example_alphadia_tsv)
 
         assert result_df.shape == (9364, 6)
-        assert result_df.index.name == PGCols.PROTEINS
+        assert result_df.index.name == PGCols.UNIPROT_IDS

--- a/tests/integration/test_pg_reader_provider.py
+++ b/tests/integration/test_pg_reader_provider.py
@@ -1,0 +1,21 @@
+"""Integration tests for protein group reader provider."""
+
+from alphabase.pg_reader import AlphaDiaPGReader, pg_reader_provider
+from alphabase.pg_reader.keys import PGCols
+
+
+class TestAlphaDiaPGReaderProvider:
+    def test_reader_provider(self) -> None:
+        """Test whether reader provider initializes alphadia PG reader correctly."""
+        reader = pg_reader_provider.get_reader("alphadia")
+
+        assert isinstance(reader, AlphaDiaPGReader)
+
+    def test_reader_provider_import(self, example_alphadia_tsv: str) -> None:
+        """Test if import works via `pg_reader_provider`"""
+        reader = pg_reader_provider.get_reader("alphadia")
+
+        result_df = reader.import_file(example_alphadia_tsv)
+
+        assert result_df.shape == (9364, 6)
+        assert result_df.index.name == PGCols.PROTEINS

--- a/tests/integration/test_pg_reader_provider.py
+++ b/tests/integration/test_pg_reader_provider.py
@@ -1,6 +1,13 @@
 """Integration tests for protein group reader provider."""
 
-from alphabase.pg_reader import AlphaDiaPGReader, DiannPGReader, pg_reader_provider
+import pytest
+
+from alphabase.pg_reader import (
+    AlphaDiaPGReader,
+    AlphaPeptPGReader,
+    DiannPGReader,
+    pg_reader_provider,
+)
 from alphabase.pg_reader.keys import PGCols
 
 
@@ -23,7 +30,7 @@ class TestAlphaDiaPGReaderProvider:
 
 class TestDiannPGReaderProvider:
     def test_reader_provider(self) -> None:
-        """Test whether reader provider initializes alphadia PG reader correctly."""
+        """Test whether reader provider initializes DIANN PG reader correctly."""
         reader = pg_reader_provider.get_reader("diann")
 
         assert isinstance(reader, DiannPGReader)
@@ -41,4 +48,47 @@ class TestDiannPGReaderProvider:
             PGCols.GENES,
             PGCols.PROTEIN_CANDIDATES,
             PGCols.DESCRIPTION,
+        ]
+
+
+class TestAlphapeptPGReaderProvider:
+    def test_reader_provider(self) -> None:
+        """Test whether reader provider initializes alphapept PG reader correctly."""
+        reader = pg_reader_provider.get_reader("alphapept")
+
+        assert isinstance(reader, AlphaPeptPGReader)
+
+    @pytest.mark.parametrize(
+        ("measurement_regex", "expected_shape", "expected_colums"),
+        [
+            # Default
+            (None, (3781, 2), ["A", "B"]),
+            # LFQ
+            ("LFQ", (3781, 2), ["A_LFQ", "B_LFQ"]),
+            # Get all
+            (".*", (3781, 4), ["A_LFQ", "B_LFQ", "A", "B"]),
+        ],
+    )
+    def test_reader_provider_import(
+        self,
+        example_alphapept_csv: str,
+        measurement_regex: str,
+        expected_shape: tuple[int, int],
+        expected_colums: list[str],
+    ) -> None:
+        """Test if diann protein group report import works via `pg_reader_provider`"""
+        reader = pg_reader_provider.get_reader(
+            "alphapept", measurement_regex=measurement_regex
+        )
+
+        result_df = reader.import_file(example_alphapept_csv)
+
+        assert result_df.shape == expected_shape
+        assert list(result_df.columns) == expected_colums
+        assert result_df.index.names == [
+            PGCols.PROTEINS,
+            PGCols.UNIPROT_IDS,
+            PGCols.ENSEMBL_IDS,
+            PGCols.SOURCE_DB,
+            PGCols.DECOY_INDICATOR,
         ]

--- a/tests/integration/test_pg_readers.py
+++ b/tests/integration/test_pg_readers.py
@@ -1,6 +1,8 @@
 """Integration tests for protein group reader."""
 
-from alphabase.pg_reader import AlphaDiaPGReader, DiannPGReader
+import pytest
+
+from alphabase.pg_reader import AlphaDiaPGReader, AlphaPeptPGReader, DiannPGReader
 from alphabase.pg_reader.keys import PGCols
 
 
@@ -27,4 +29,42 @@ class TestDiannPGReaderImportIntegration:
             PGCols.GENES,
             PGCols.PROTEIN_CANDIDATES,
             PGCols.DESCRIPTION,
+        ]
+
+
+class TestAlphapeptPGReaderImportIntegration:
+    @pytest.mark.parametrize(
+        ("measurement_regex", "expected_shape", "expected_colums"),
+        [
+            # Default
+            (None, (3781, 2), ["A", "B"]),
+            # LFQ
+            ("LFQ", (3781, 2), ["A_LFQ", "B_LFQ"]),
+            # Get all
+            (".*", (3781, 4), ["A_LFQ", "B_LFQ", "A", "B"]),
+        ],
+    )
+    def test_import_real_file(
+        self,
+        example_alphapept_csv: str,
+        measurement_regex: str,
+        expected_shape: tuple[int, int],
+        expected_colums: list[str],
+    ) -> None:
+        """Test alphapept protein group reader import with real data.
+
+        Tests whether the reader can import raw data (default), LFQ data, and all columns
+        """
+        reader = AlphaPeptPGReader(measurement_regex=measurement_regex)
+
+        result_df = reader.import_file(example_alphapept_csv)
+
+        assert result_df.shape == expected_shape
+        assert list(result_df.columns) == expected_colums
+        assert result_df.index.names == [
+            PGCols.PROTEINS,
+            PGCols.UNIPROT_IDS,
+            PGCols.ENSEMBL_IDS,
+            PGCols.SOURCE_DB,
+            PGCols.DECOY_INDICATOR,
         ]

--- a/tests/integration/test_pg_readers.py
+++ b/tests/integration/test_pg_readers.py
@@ -1,6 +1,6 @@
 """Integration tests for protein group reader."""
 
-from alphabase.pg_reader import AlphaDiaPGReader
+from alphabase.pg_reader import AlphaDiaPGReader, DiannPGReader
 from alphabase.pg_reader.keys import PGCols
 
 
@@ -12,3 +12,19 @@ class TestAlphaDiaPGReaderImportIntegration:
 
         assert result_df.shape == (9364, 6)
         assert result_df.index.name == PGCols.UNIPROT_IDS
+
+
+class TestDiannPGReaderImportIntegration:
+    def test_import_real_file(self, example_diann_tsv: str) -> None:
+        reader = DiannPGReader()
+
+        result_df = reader.import_file(example_diann_tsv)
+
+        assert result_df.shape == (10, 20)
+        assert result_df.index.names == [
+            PGCols.PROTEINS,
+            PGCols.UNIPROT_IDS,
+            PGCols.GENES,
+            PGCols.PROTEIN_CANDIDATES,
+            PGCols.DESCRIPTION,
+        ]

--- a/tests/integration/test_pg_readers.py
+++ b/tests/integration/test_pg_readers.py
@@ -11,4 +11,4 @@ class TestAlphaDiaPGReaderImportIntegration:
         result_df = reader.import_file(example_alphadia_tsv)
 
         assert result_df.shape == (9364, 6)
-        assert result_df.index.name == PGCols.PROTEINS
+        assert result_df.index.name == PGCols.UNIPROT_IDS

--- a/tests/integration/test_pg_readers.py
+++ b/tests/integration/test_pg_readers.py
@@ -1,0 +1,14 @@
+"""Integration tests for protein group reader."""
+
+from alphabase.pg_reader import AlphaDiaPGReader
+from alphabase.pg_reader.keys import PGCols
+
+
+class TestAlphaDiaPGReaderImportIntegration:
+    def test_import_real_file(self, example_alphadia_tsv: str) -> None:
+        reader = AlphaDiaPGReader()
+
+        result_df = reader.import_file(example_alphadia_tsv)
+
+        assert result_df.shape == (9364, 6)
+        assert result_df.index.name == PGCols.PROTEINS

--- a/tests/unit/pg_reader/test_alphadia_reader.py
+++ b/tests/unit/pg_reader/test_alphadia_reader.py
@@ -1,0 +1,149 @@
+"""Unit tests for AlphaDia PG reader."""
+
+import os
+from pathlib import Path
+from typing import Any, Generator
+from unittest.mock import Mock, patch
+
+import pandas as pd
+import pytest
+
+from alphabase.pg_reader import AlphaDiaPGReader, pg_reader_provider
+from alphabase.pg_reader.keys import PGCols
+from alphabase.tools.data_downloader import DataShareDownloader
+
+
+@pytest.fixture
+def mock_yaml_config() -> dict[str, Any]:
+    """Mock YAML configuration for AlphaDia."""
+    return {
+        "alphadia": {
+            "reader_type": "alphadia",
+            "column_mapping": {
+                "proteins": "pg",
+            },
+            "measurement_regex": None,  # AlphaDia typically has minimal format
+        }
+    }
+
+
+@pytest.fixture
+def minimal_alphadia_df() -> pd.DataFrame:
+    """Create a sample AlphaDia protein group dataframe.
+
+    alphaDIA produces minimal output: features x samples
+    with sample names as columns and protein IDs as index.
+    """
+    return pd.DataFrame(
+        {
+            "pg": ["P12345", "Q67890", "R11111"],
+            "sample_01": [1000.5, 2000.3, 3000.7],
+            "sample_02": [1100.2, 2100.8, 3100.4],
+            "sample_03": [1200.9, 2200.1, 3200.5],
+        }
+    )
+
+
+@pytest.fixture
+def minimal_alphadia_df_standardized(minimal_alphadia_df: pd.DataFrame) -> pd.DataFrame:
+    """Expected alphabase output from minimal alphadia input."""
+    return minimal_alphadia_df.rename(columns={"pg": PGCols.PROTEINS}).set_index(
+        PGCols.PROTEINS
+    )
+
+
+@pytest.fixture
+def minimal_alphadia_tsv(
+    tmp_path: Path, minimal_alphadia_df: pd.DataFrame
+) -> Generator[str, None, None]:
+    """Create temporary tsv file of PG matrix"""
+    # Setup
+    path = tmp_path / "alphadia.pg.tsv"
+    minimal_alphadia_df.to_csv(path, sep="\t", index=False)
+
+    # Yield
+    yield str(path)
+
+    # Tear down
+    os.remove(path)
+
+
+@pytest.fixture
+def example_alphadia_tsv(tmp_path) -> Generator[pd.DataFrame, None, None]:
+    """Get and parse real alphadia PG report matrix."""
+    URL = "https://datashare.biochem.mpg.de/s/cN1tmElfgKOe1cW"
+
+    download_path = DataShareDownloader(url=URL, output_dir=tmp_path).download()
+    yield download_path
+
+    os.remove(download_path)
+
+
+class TestAlphaDiaPGReaderInit:
+    """Test initialization of AlphaDiaPGReader."""
+
+    @patch("alphabase.pg_reader.pg_reader.pg_reader_yaml")
+    def test_init_with_custom_params(
+        self, mock_yaml: Mock, mock_yaml_config: dict[str, Any]
+    ) -> None:
+        """Test initialization with custom parameters."""
+        mock_yaml.__getitem__.return_value = mock_yaml_config["alphadia"]
+
+        custom_mapping = {"protein": "CustomProteinCol"}
+        custom_regex = r"sample_\d+"
+
+        reader = AlphaDiaPGReader(
+            column_mapping=custom_mapping, measurement_regex=custom_regex
+        )
+
+        assert reader.column_mapping == custom_mapping
+        assert reader.measurement_regex == custom_regex
+
+
+class TestAlphaDiaPGReaderImport:
+    """Test file import functionality."""
+
+    @patch("alphabase.pg_reader.pg_reader.pg_reader_yaml")
+    def test_import_standard_file(
+        self,
+        mock_yaml: Mock,
+        mock_yaml_config: dict[str, Any],
+        minimal_alphadia_df_standardized: pd.DataFrame,
+        minimal_alphadia_tsv: str,
+    ):
+        """Test importing a standard AlphaDia PG file."""
+        mock_yaml.__getitem__.return_value = mock_yaml_config["alphadia"]
+
+        reader = AlphaDiaPGReader()
+
+        result_df = reader.import_file(minimal_alphadia_tsv)
+
+        # Check structure
+        pd.testing.assert_frame_equal(result_df, minimal_alphadia_df_standardized)
+
+
+class TestAlphaDiaPGReaderImportIntegration:
+    def test_import_real_file(self, example_alphadia_tsv: str) -> None:
+        reader = AlphaDiaPGReader()
+
+        result_df = reader.import_file(example_alphadia_tsv)
+
+        assert result_df.shape == (9364, 6)
+        assert result_df.index.name == PGCols.PROTEINS
+
+
+class TestAlphaDiaPGReaderProvider:
+    def test_reader_provider(self) -> None:
+        """Test whether reader provider initializes alphadia PG reader correctly."""
+        reader = pg_reader_provider.get_reader("alphadia")
+
+        assert isinstance(reader, AlphaDiaPGReader)
+
+    def test_reader_provider_import(self, example_alphadia_tsv: str) -> None:
+        """Test if import works via `pg_reader_provider`"""
+        reader = pg_reader_provider.get_reader("alphadia")
+
+        result_df = reader.import_file(example_alphadia_tsv)
+
+        assert result_df.shape == (9364, 6)
+        assert result_df.index.name == PGCols.PROTEINS

--- a/tests/unit/pg_reader/test_alphadia_reader.py
+++ b/tests/unit/pg_reader/test_alphadia_reader.py
@@ -8,9 +8,8 @@ from unittest.mock import Mock, patch
 import pandas as pd
 import pytest
 
-from alphabase.pg_reader import AlphaDiaPGReader, pg_reader_provider
+from alphabase.pg_reader import AlphaDiaPGReader
 from alphabase.pg_reader.keys import PGCols
-from alphabase.tools.data_downloader import DataShareDownloader
 
 
 @pytest.fixture
@@ -68,17 +67,6 @@ def minimal_alphadia_tsv(
     os.remove(path)
 
 
-@pytest.fixture
-def example_alphadia_tsv(tmp_path) -> Generator[pd.DataFrame, None, None]:
-    """Get and parse real alphadia PG report matrix."""
-    URL = "https://datashare.biochem.mpg.de/s/cN1tmElfgKOe1cW"
-
-    download_path = DataShareDownloader(url=URL, output_dir=tmp_path).download()
-    yield download_path
-
-    os.remove(download_path)
-
-
 class TestAlphaDiaPGReaderInit:
     """Test initialization of AlphaDiaPGReader."""
 
@@ -120,30 +108,3 @@ class TestAlphaDiaPGReaderImport:
 
         # Check structure
         pd.testing.assert_frame_equal(result_df, minimal_alphadia_df_standardized)
-
-
-class TestAlphaDiaPGReaderImportIntegration:
-    def test_import_real_file(self, example_alphadia_tsv: str) -> None:
-        reader = AlphaDiaPGReader()
-
-        result_df = reader.import_file(example_alphadia_tsv)
-
-        assert result_df.shape == (9364, 6)
-        assert result_df.index.name == PGCols.PROTEINS
-
-
-class TestAlphaDiaPGReaderProvider:
-    def test_reader_provider(self) -> None:
-        """Test whether reader provider initializes alphadia PG reader correctly."""
-        reader = pg_reader_provider.get_reader("alphadia")
-
-        assert isinstance(reader, AlphaDiaPGReader)
-
-    def test_reader_provider_import(self, example_alphadia_tsv: str) -> None:
-        """Test if import works via `pg_reader_provider`"""
-        reader = pg_reader_provider.get_reader("alphadia")
-
-        result_df = reader.import_file(example_alphadia_tsv)
-
-        assert result_df.shape == (9364, 6)
-        assert result_df.index.name == PGCols.PROTEINS

--- a/tests/unit/pg_reader/test_alphapept_pg_reader.py
+++ b/tests/unit/pg_reader/test_alphapept_pg_reader.py
@@ -1,6 +1,6 @@
 import pytest
 
-from alphabase.pg_reader.alphapept_pg_reader import AlphaPeptPGReader
+from alphabase.pg_reader import AlphaPeptPGReader
 
 
 class TestAlphapeptPGReader:

--- a/tests/unit/pg_reader/test_alphapept_pg_reader.py
+++ b/tests/unit/pg_reader/test_alphapept_pg_reader.py
@@ -1,0 +1,119 @@
+import pytest
+
+from alphabase.pg_reader.alphapept_pg_reader import AlphaPeptPGReader
+
+
+class TestAlphapeptPGReader:
+    """Test suite for AlphapeptPGReader._parse_alphapept_index method."""
+
+    @pytest.fixture
+    def reader(self):
+        """Create a mock AlphapeptPGReader instance."""
+        return AlphaPeptPGReader()
+
+    @pytest.mark.parametrize(
+        "identifier,expected",
+        [
+            # Test case 1: Standard UniProt Swiss-Prot format
+            (
+                "sp|Q9NQT4|EXOS5_HUMAN",
+                {
+                    "source_db": "sp",
+                    "uniprot_ids": "Q9NQT4",
+                    "ensembl_ids": "na",
+                    "proteins": "EXOS5_HUMAN",
+                    "is_decoy": False,
+                },
+            ),
+            # Test case 2: UniProt ID only
+            (
+                "Q0IIK2",
+                {
+                    "source_db": "na",
+                    "uniprot_ids": "Q0IIK2",
+                    "ensembl_ids": "na",
+                    "proteins": "na",
+                    "is_decoy": False,
+                },
+            ),
+            # Test case 3: Multiple UniProt entries
+            (
+                "sp|Q9H2K8|TAOK3_HUMAN,sp|Q7L7X3|TAOK1_HUMAN",
+                {
+                    "source_db": "sp;sp",
+                    "uniprot_ids": "Q9H2K8;Q7L7X3",
+                    "ensembl_ids": "na;na",
+                    "proteins": "TAOK3_HUMAN;TAOK1_HUMAN",
+                    "is_decoy": False,
+                },
+            ),
+            # Test case 4: Ensembl format
+            (
+                "ENSEMBL:ENSBTAP00000024146",
+                {
+                    "source_db": "ENSEMBL",
+                    "uniprot_ids": "na",
+                    "ensembl_ids": "ENSBTAP00000024146",
+                    "proteins": "na",
+                    "is_decoy": False,
+                },
+            ),
+            # Test case 5: Mixed Ensembl and UniProt
+            (
+                "ENSEMBL:ENSBTAP00000024146,sp|P35520|CBS_HUMAN",
+                {
+                    "source_db": "ENSEMBL;sp",
+                    "uniprot_ids": "na;P35520",
+                    "ensembl_ids": "ENSBTAP00000024146;na",
+                    "proteins": "na;CBS_HUMAN",
+                    "is_decoy": False,
+                },
+            ),
+            # Test case 6: Decoy protein with REV__ prefix
+            (
+                "REV__sp|Q13085|ACACA_HUMAN",
+                {
+                    "source_db": "REV__sp",
+                    "uniprot_ids": "Q13085",
+                    "ensembl_ids": "na",
+                    "proteins": "ACACA_HUMAN",
+                    "is_decoy": True,
+                },
+            ),
+        ],
+    )
+    def test_parse_alphapept_index(self, reader, identifier, expected):
+        """Test _parse_alphapept_index with various identifier formats."""
+
+        reader = AlphaPeptPGReader()
+        result = reader._parse_alphapept_index(identifier)
+
+        # Assert that the result matches the expected output
+        assert result == expected
+
+    def test_parse_alphapept_index_multiple_decoys(self, reader):
+        """Test _parse_alphapept_index with multiple decoy entries."""
+        identifier = "REV__sp|Q13085|ACACA_HUMAN,REV__sp|P35520|CBS_HUMAN"
+        expected = {
+            "source_db": "REV__sp;REV__sp",
+            "uniprot_ids": "Q13085;P35520",
+            "ensembl_ids": "na;na",
+            "proteins": "ACACA_HUMAN;CBS_HUMAN",
+            "is_decoy": True,
+        }
+        result = reader._parse_alphapept_index(identifier)
+        assert result == expected
+
+    def test_parse_alphapept_index_mixed_decoy_regular(self, reader):
+        """Test _parse_alphapept_index with mixed decoy and regular entries."""
+        identifier = "sp|Q9NQT4|EXOS5_HUMAN,REV__sp|Q13085|ACACA_HUMAN"
+        # This tests whether is_decoy is True if ANY entry is a decoy
+        expected = {
+            "source_db": "sp;REV__sp",
+            "uniprot_ids": "Q9NQT4;Q13085",
+            "ensembl_ids": "na;na",
+            "proteins": "EXOS5_HUMAN;ACACA_HUMAN",
+            "is_decoy": True,  # Assuming True if any entry is decoy
+        }
+        result = reader._parse_alphapept_index(identifier)
+        assert result == expected

--- a/tests/unit/pg_reader/test_pg_reader.py
+++ b/tests/unit/pg_reader/test_pg_reader.py
@@ -1,0 +1,247 @@
+"""Unit tests for PGReaderBase class."""
+
+import os
+from typing import Any, Generator
+from unittest.mock import Mock, patch
+
+import pandas as pd
+import pytest
+
+from alphabase.pg_reader.pg_reader import PGReaderBase
+
+
+class ExamplePGReader(PGReaderBase):
+    """Test class"""
+
+    _reader_type = "test_reader"
+
+
+@pytest.fixture
+def mock_yaml_data() -> dict[str, Any]:
+    """Mock YAML configuration data."""
+    return {
+        "test_reader": {
+            "column_mapping": {
+                "protein": "Protein ID",
+                "gene": "Gene Name",
+                "description": "Description",
+            },
+            "measurement_regex": r"Sample_\d+_LFQ",
+        }
+    }
+
+
+@pytest.fixture
+def sample_df() -> pd.DataFrame:
+    """Create a sample dataframe for testing."""
+    return pd.DataFrame(
+        {
+            "Protein ID": ["P001", "P002", "P003"],
+            "Gene Name": ["GENE1", "GENE2", "GENE3"],
+            "Description": ["Desc1", "Desc2", "Desc3"],
+            "Sample_1_LFQ": [100.0, 200.0, 300.0],
+            "Sample_2_LFQ": [150.0, 250.0, 350.0],
+            "Sample_1_raw": [90.0, 190.0, 290.0],
+            "Sample_2_raw": [140.0, 240.0, 340.0],
+        }
+    )
+
+
+@pytest.fixture
+def sample_csv(tmp_path, sample_df: pd.DataFrame) -> Generator[str, None, None]:
+    """Create temporary csv file of PG matrix"""
+    # Setup
+    path = tmp_path / "sample.pg.csv"
+    sample_df.to_csv(path, index=True)
+
+    # Yield
+    yield str(path)
+
+    # Tear down
+    os.remove(path)
+
+
+@pytest.fixture
+def sample_tsv(tmp_path, sample_df: pd.DataFrame) -> Generator[str, None, None]:
+    """Create temporary tsv file of PG matrix"""
+    # Setup
+    path = tmp_path / "sample.pg.tsv"
+    sample_df.to_csv(path, sep="\t", index=True)
+
+    # Yield
+    yield str(path)
+
+    # Tear down
+    os.remove(path)
+
+
+@pytest.fixture
+def sample_hdf(tmp_path, sample_df: pd.DataFrame) -> Generator[str, None, None]:
+    """Create temporary hdf file of PG matrix"""
+    # Setup
+    path = tmp_path / "sample.pg.hdf"
+    sample_df.reset_index().to_hdf(path, key=None)
+
+    # Yield
+    yield str(path)
+
+    # Tear down
+    os.remove(path)
+
+
+@pytest.fixture
+def empty_df() -> pd.DataFrame:
+    """Create an empty dataframe."""
+    return pd.DataFrame()
+
+
+class TestPGReaderBaseInit:
+    """Test initialization of PGReaderBase."""
+
+    @patch("alphabase.pg_reader.pg_reader.pg_reader_yaml")
+    def test_init_with_defaults(
+        self, mock_yaml: Mock, mock_yaml_data: dict[str, Any]
+    ) -> None:
+        """Test initialization with default values from YAML."""
+        mock_yaml.__getitem__.return_value = mock_yaml_data["test_reader"]
+
+        reader = ExamplePGReader()
+
+        assert reader.column_mapping == mock_yaml_data["test_reader"]["column_mapping"]
+        assert (
+            reader.measurement_regex
+            == mock_yaml_data["test_reader"]["measurement_regex"]
+        )
+
+    @patch("alphabase.pg_reader.pg_reader.pg_reader_yaml")
+    def test_init_with_custom_column_mapping(
+        self, mock_yaml: Mock, mock_yaml_data: dict[str, Any]
+    ) -> None:
+        """Test initialization with custom column mapping."""
+        mock_yaml.__getitem__.return_value = mock_yaml_data["test_reader"]
+        custom_mapping = {"protein": "ProteinCol", "gene": "GeneCol"}
+
+        reader = ExamplePGReader(column_mapping=custom_mapping)
+
+        assert reader.column_mapping == custom_mapping
+        assert (
+            reader.measurement_regex
+            == mock_yaml_data["test_reader"]["measurement_regex"]
+        )
+
+    @patch("alphabase.pg_reader.pg_reader.pg_reader_yaml")
+    def test_init_with_custom_measurement_regex(
+        self, mock_yaml: Mock, mock_yaml_data: dict[str, Any]
+    ) -> None:
+        """Test initialization with custom measurement regex."""
+        mock_yaml.__getitem__.return_value = mock_yaml_data["test_reader"]
+        custom_regex = r".*_intensity$"
+
+        reader = ExamplePGReader(measurement_regex=custom_regex)
+
+        assert reader.column_mapping == mock_yaml_data["test_reader"]["column_mapping"]
+        assert reader.measurement_regex == custom_regex
+
+
+class TestAddColumnMapping:
+    """Test add_column_mapping method."""
+
+    @patch("alphabase.pg_reader.pg_reader.pg_reader_yaml")
+    def test_add_new_mapping(self, mock_yaml, mock_yaml_data):
+        """Test adding new column mappings."""
+        mock_yaml.__getitem__.return_value = mock_yaml_data["test_reader"]
+        reader = ExamplePGReader()
+
+        new_mapping = {"peptides": "Peptide Count"}
+        reader.add_column_mapping(new_mapping)
+
+        expected = {**mock_yaml_data["test_reader"]["column_mapping"], **new_mapping}
+        assert reader.column_mapping == expected
+
+    @patch("alphabase.pg_reader.pg_reader.pg_reader_yaml")
+    def test_override_existing_mapping(self, mock_yaml, mock_yaml_data):
+        """Test overriding existing column mappings."""
+        mock_yaml.__getitem__.return_value = mock_yaml_data["test_reader"]
+        reader = ExamplePGReader()
+
+        override_mapping = {"protein": "New Protein Col"}
+        reader.add_column_mapping(override_mapping)
+
+        assert reader.column_mapping["protein"] == "New Protein Col"
+        assert reader.column_mapping["gene"] == "Gene Name"  # Unchanged
+
+
+class TestPreProcess:
+    """Test _pre_process method."""
+
+    @patch("alphabase.pg_reader.pg_reader.pg_reader_yaml")
+    def test_pre_process_default(self, mock_yaml, mock_yaml_data, sample_df):
+        """Test default pre-processing (should return unchanged df)."""
+        mock_yaml.__getitem__.return_value = mock_yaml_data["test_reader"]
+        reader = ExamplePGReader()
+
+        result_df = reader._pre_process(sample_df)
+        pd.testing.assert_frame_equal(result_df, sample_df)
+
+
+class TestTranslateColumns:
+    """Test _translate_columns method."""
+
+    @patch("alphabase.pg_reader.pg_reader.pg_reader_yaml")
+    def test_translate_columns(self, mock_yaml, mock_yaml_data, sample_df):
+        """Test column translation."""
+        mock_yaml.__getitem__.return_value = mock_yaml_data["test_reader"]
+        reader = ExamplePGReader()
+
+        # Should only find the standardized names (values) and not the original names (keys)
+        mapping = {"Protein ID": "protein", "Gene Name": "gene"}
+        result_df = reader._translate_columns(sample_df, mapping)
+
+        assert "protein" in result_df.columns
+        assert "gene" in result_df.columns
+        assert "Protein ID" not in result_df.columns
+        assert "Gene Name" not in result_df.columns
+        # Description was not changed by Translation as it is not contained in the mapping
+        assert "Description" in result_df.columns
+
+
+class TestFilterMeasurement:
+    """Test _filter_measurement method."""
+
+    @patch("alphabase.pg_reader.pg_reader.pg_reader_yaml")
+    def test_filter_with_regex(self, mock_yaml, mock_yaml_data, sample_df):
+        """Test filtering columns with regex."""
+        mock_yaml.__getitem__.return_value = mock_yaml_data["test_reader"]
+        reader = ExamplePGReader()
+
+        regex = r"Sample_\d+_LFQ"
+        result_df = reader._filter_measurement(sample_df, regex)
+
+        assert list(result_df.columns) == ["Sample_1_LFQ", "Sample_2_LFQ"]
+
+    @patch("alphabase.pg_reader.pg_reader.pg_reader_yaml")
+    def test_filter_with_extra_columns(self, mock_yaml, mock_yaml_data, sample_df):
+        """Test filtering with extra columns."""
+        mock_yaml.__getitem__.return_value = mock_yaml_data["test_reader"]
+        reader = ExamplePGReader()
+
+        regex = r"Sample_\d+_LFQ"
+        extra_cols = ["Protein ID", "Gene Name"]
+        result_df = reader._filter_measurement(
+            sample_df, regex, extra_columns=extra_cols
+        )
+
+        expected_cols = ["Sample_1_LFQ", "Sample_2_LFQ", "Protein ID", "Gene Name"]
+        assert list(result_df.columns) == expected_cols
+
+    @patch("alphabase.pg_reader.pg_reader.pg_reader_yaml")
+    def test_filter_no_matches_warning(self, mock_yaml, mock_yaml_data, sample_df):
+        """Test warning when regex matches no columns."""
+        mock_yaml.__getitem__.return_value = mock_yaml_data["test_reader"]
+        reader = ExamplePGReader()
+
+        regex = r"NonExistent.*"
+        with pytest.warns(UserWarning, match="regex .* did not match any columns"):
+            result_df = reader._filter_measurement(sample_df, regex)
+
+        assert result_df.empty

--- a/tests/unit/pg_reader/test_pg_reader.py
+++ b/tests/unit/pg_reader/test_pg_reader.py
@@ -130,12 +130,12 @@ class TestPGReaderBaseInit:
         )
 
     @patch("alphabase.pg_reader.pg_reader.pg_reader_yaml")
+    @pytest.mark.parametrize(("custom_regex",), [(r".*_intensity$",), ("_intensity",)])
     def test_init_with_custom_measurement_regex(
-        self, mock_yaml: Mock, mock_yaml_data: dict[str, Any]
+        self, mock_yaml: Mock, mock_yaml_data: dict[str, Any], custom_regex: str
     ) -> None:
         """Test initialization with custom measurement regex."""
         mock_yaml.__getitem__.return_value = mock_yaml_data["test_reader"]
-        custom_regex = r".*_intensity$"
 
         reader = ExamplePGReader(measurement_regex=custom_regex)
 

--- a/tests/unit/pg_reader/test_pg_reader_provider.py
+++ b/tests/unit/pg_reader/test_pg_reader_provider.py
@@ -1,0 +1,84 @@
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+from alphabase.pg_reader.pg_reader import PGReaderBase, PGReaderProvider
+
+
+class ExamplePGReader(PGReaderBase):
+    """Test class"""
+
+    _reader_type = "test_reader"
+
+
+@pytest.fixture
+def mock_yaml_data() -> dict[str, Any]:
+    """Mock YAML configuration data."""
+    return {
+        "test_reader": {
+            "column_mapping": {
+                "protein": "Protein ID",
+                "gene": "Gene Name",
+                "description": "Description",
+            },
+            "measurement_regex": r"Sample_\d+_LFQ",
+        }
+    }
+
+
+class TestPGReaderProvider:
+    """Test PGReaderProvider class."""
+
+    @patch("alphabase.pg_reader.pg_reader.pg_reader_yaml")
+    def test_register_and_get_reader(
+        self, pg_reader_yaml: Mock, mock_yaml_data: dict[str, Any]
+    ) -> None:
+        """Test registering and getting a reader."""
+
+        pg_reader_yaml.__getitem__.test_reader = mock_yaml_data
+        provider = PGReaderProvider()
+        provider.register_reader("test_reader", ExamplePGReader)
+
+        reader = provider.get_reader("test_reader")
+
+        assert isinstance(reader, ExamplePGReader)
+
+    def test_get_unknown_reader_raises_error(self) -> None:
+        """Test that getting an unknown reader raises KeyError."""
+        provider = PGReaderProvider()
+
+        with pytest.raises(KeyError, match="Unknown reader type 'unknown'"):
+            provider.get_reader("unknown")
+
+    @patch("alphabase.pg_reader.pg_reader.pg_reader_yaml")
+    def test_get_reader_with_kwargs(
+        self, mock_yaml: Mock, mock_yaml_data: dict[str, Any]
+    ) -> None:
+        """Test getting a reader with custom parameters."""
+        mock_yaml.__getitem__.return_value = mock_yaml_data["test_reader"]
+        provider = PGReaderProvider()
+        provider.register_reader("test_reader", ExamplePGReader)
+
+        custom_mapping = {"protein": "CustomProtein"}
+        reader = provider.get_reader("test_reader", column_mapping=custom_mapping)
+
+        assert reader.column_mapping == custom_mapping
+
+    @patch("alphabase.pg_reader.pg_reader.pg_reader_yaml")
+    def test_get_reader_by_yaml(
+        self, mock_yaml: Mock, mock_yaml_data: dict[str, Any]
+    ) -> None:
+        """Test getting a reader from a YAML configuration."""
+        mock_yaml.__getitem__.return_value = mock_yaml_data["test_reader"]
+        provider = PGReaderProvider()
+        provider.register_reader("test_reader", ExamplePGReader)
+
+        yaml_dict = {
+            "reader_type": "test_reader",
+            "column_mapping": {"protein": "YAMLProtein"},
+        }
+        reader = provider.get_reader_by_yaml(yaml_dict)
+
+        assert isinstance(reader, ExamplePGReader)
+        assert reader.column_mapping == {"protein": "YAMLProtein"}


### PR DESCRIPTION
Implements the protein group reader for AlphaPept protein group reports 

This is the first reader that requires regex logic for reading. Key challenges are that alphapept dataframes do not contain a name in the feature column and that feature names are extracted from custom fasta headers, i.e. it is difficult to parse the feature names. Implements a custom `_pre_process` logic that supports standard uniprot + ensembl entries. The parsing logic is implemented in a class-specific function `_parse_alphapept_index`, which is tested based on the examples provided in the example data. 

