### PR TITLE
[Fix] Hotfix alphabase hdf5 

### DIFF
--- a/.github/workflows/pip_installation.yml
+++ b/.github/workflows/pip_installation.yml
@@ -22,7 +22,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
-      install-script: pip_install.sh stable,tests ${{ matrix.python-version }}-${{ matrix.os}}-alphabase ${{ matrix.os }}
+      install-script: pip_install.sh stable,tests ${{ matrix.python-version }}-${{ matrix.os}}-alphabase ${{ matrix.python-version }} ${{ matrix.os }}
 
   loose_installation:
     name: Test loose pip installation on ${{ matrix.os }}
@@ -34,4 +34,4 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
-      install-script: pip_install.sh tests ${{ matrix.python-version }}-${{ matrix.os}}-alphabase ${{ matrix.os }}
+      install-script: pip_install.sh tests ${{ matrix.python-version }}-${{ matrix.os}}-alphabase ${{ matrix.python-version }} ${{ matrix.os }}

--- a/.github/workflows/pip_installation.yml
+++ b/.github/workflows/pip_installation.yml
@@ -22,7 +22,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
-      install-script: pip_install.sh stable,tests ${{ matrix.python-version }}-${{ matrix.os}}-alphabase ${{ matrix.python-version }} ${{ matrix.os }}
+      install-script: pip_install.sh stable,tests alphabase-env ${{ matrix.python-version }} ${{ matrix.os }}
 
   loose_installation:
     name: Test loose pip installation on ${{ matrix.os }}
@@ -34,4 +34,4 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
-      install-script: pip_install.sh tests ${{ matrix.python-version }}-${{ matrix.os}}-alphabase ${{ matrix.python-version }} ${{ matrix.os }}
+      install-script: pip_install.sh tests alphabase-env ${{ matrix.python-version }} ${{ matrix.os }}

--- a/.github/workflows/pip_installation.yml
+++ b/.github/workflows/pip_installation.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest, macos-latest-xlarge]
-        python-version : [3.9]
+        python-version: [3.9]
     uses: ./.github/workflows/_run_tests.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/pip_installation.yml
+++ b/.github/workflows/pip_installation.yml
@@ -22,15 +22,16 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
-      install-script: pip_install.sh stable,tests
+      install-script: pip_install.sh stable,tests ${{ matrix.python-version }}-${{ matrix.os}}-alphabase ${{ matrix.os }}
 
   loose_installation:
     name: Test loose pip installation on ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest, macos-latest-xlarge]
+        python-version : [3.9]
     uses: ./.github/workflows/_run_tests.yml
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
-      install-script: pip_install.sh tests
+      install-script: pip_install.sh tests ${{ matrix.python-version }}-${{ matrix.os}}-alphabase ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -102,7 +102,13 @@ AlphaBase like this. Also note the double quotes `"`.
 If you are using the `quant_reader` module, it is advisable to add the
 `dask-stable` or `dask` extras to speed up processing large files.
 
-**NOTE for macOS users**: Due to compilation issues with PyTables on macOS, you may encounter build errors when installing AlphaBase. If this happens, install PyTables via conda/mamba first:
+**NOTE for macOS users**: Due to compilation issues with PyTables on macOS, you may encounter build errors when installing AlphaBase.
+These may include
+
+- `ERROR:: Could not find a local HDF5 installation`
+- `ERROR: Failed building wheel for tables`
+
+If this happens, install PyTables via conda/mamba first:
 ```bash
 conda install -c conda-forge pytables
 # or

--- a/README.md
+++ b/README.md
@@ -97,10 +97,19 @@ be compatible with:
 pip install "alphabase[stable]"
 ```
 
-NOTE: You might need to run `pip install -U pip` before installing
+**NOTE**: You might need to run `pip install -U pip` before installing
 AlphaBase like this. Also note the double quotes `"`.
 If you are using the `quant_reader` module, it is advisable to add the
 `dask-stable` or `dask` extras to speed up processing large files.
+
+**NOTE for macOS users**: Due to compilation issues with PyTables on macOS, you may encounter build errors when installing AlphaBase. If this happens, install PyTables via conda/mamba first:
+```bash
+conda install -c conda-forge pytables
+# or
+mamba install -c conda-forge pytables
+```
+Then proceed with the pip installation of AlphaBase.
+
 
 For those who are really adventurous, it is also possible to directly
 install any branch (e.g. `@main`) with any extras

--- a/misc/pip_install.sh
+++ b/misc/pip_install.sh
@@ -19,6 +19,7 @@ else
 fi
 
 # pytables has known issues on MacOS for pg-readers - install from conda
+# https://github.com/PyTables/PyTables/issues/219#issuecomment-24117053
 if [ "$OS" = "macOS-latest" ]; then
   conda install -n $ENV_NAME -c conda-forge pytables -y
 elif ["$OS" = "macos-latest-xlarge"]; then

--- a/misc/pip_install.sh
+++ b/misc/pip_install.sh
@@ -20,9 +20,7 @@ fi
 
 # pytables has known issues on MacOS for pg-readers - install from conda
 # https://github.com/PyTables/PyTables/issues/219#issuecomment-24117053
-if [ "$OS" = "macOS-latest" ]; then
-  conda install -n $ENV_NAME -c conda-forge pytables -y
-elif ["$OS" = "macos-latest-xlarge"]; then
+if [[ "$OS" = "macOS-latest" || "$OS" = "macos-latest-xlarge" ]]; then
   conda install -n $ENV_NAME -c conda-forge pytables -y
 fi
 

--- a/misc/pip_install.sh
+++ b/misc/pip_install.sh
@@ -8,6 +8,7 @@ set -e -u
 INSTALL_TYPE=$1 # stable, loose, etc..
 ENV_NAME=${2:-alphabase}
 PYTHON_VERSION=${3:-3.9}
+OS=${4:-nan}
 
 conda create -n $ENV_NAME python=$PYTHON_VERSION -y
 
@@ -15,6 +16,13 @@ if [ "$INSTALL_TYPE" = "loose" ]; then
   INSTALL_STRING=""
 else
   INSTALL_STRING="[${INSTALL_TYPE}]"
+fi
+
+# pytables has known issues on MacOS for pg-readers - install from conda
+if [ "$OS" = "macOS-latest" ]; then
+  conda install -n $ENV_NAME -c conda-forge pytables -y
+elif ["$OS" = "macos-latest-xlarge"]; then
+  conda install -n $ENV_NAME -c conda-forge pytables -y
 fi
 
 # print pip environment for reproducibility


### PR DESCRIPTION
Fix MacOS-specific installation error that is caused by `pytables` dependency. PyTables does not find some relevant headers of the hdf5 lib on MacOS, which is a known issue. 
- https://github.com/PyTables/PyTables/issues/219#issuecomment-24117053

The simplest fix is to install pytables from `conda`. Implement MacOS-specific installation strategy in the `/misc/pip_install.sh` script and add user-facing documentation in the README. 