### PR TITLE
Add spectronaut PG column to pg_reader.yaml

### DIFF
--- a/alphabase/constants/const_files/pg_reader.yaml
+++ b/alphabase/constants/const_files/pg_reader.yaml
@@ -79,7 +79,7 @@ maxquant:
 spectronaut:
   reader_type: "spectronaut"
   column_mapping:
-    "proteins": ["PG.ProteinNames", "PG_ProteinGroups", "PG.ProteinGroups"]
+    "proteins": ["PG.ProteinNames", "PG_ProteinGroups", "PG.ProteinGroups"] # Spectronaut 15 requires PG.ProteinGroups
     "genes": "PG.Genes"
     "uniprot_ids": "PG.UniProtIds"
   measurement_regex:


### PR DESCRIPTION
Apparently there is a new column in Spectronaut PG tables, which was previously not in the pg_reader config. It has been added now and tested against new Spectronaut PG tables.