### PR TITLE
fix Downcasting dtype arrays warning: 

### DIFF
--- a/alphabase/quantification/quant_reader/table_reformatter.py
+++ b/alphabase/quantification/quant_reader/table_reformatter.py
@@ -72,9 +72,15 @@ def merge_protein_cols_and_config_dict(
 
 def join_columns(df, columns, separator="_"):
     if len(columns) == 1:
-        return df[columns[0]].fillna("nan").astype(str)
+        return df[columns[0]].fillna("nan").infer_objects(copy=False).astype(str)
     else:
-        return df[columns].fillna("nan").astype(str).agg(separator.join, axis=1)
+        return (
+            df[columns]
+            .fillna("nan")
+            .infer_objects(copy=False)
+            .astype(str)
+            .agg(separator.join, axis=1)
+        )
 
 
 def get_ionname_columns(ion_dict, ion_hierarchy_local):


### PR DESCRIPTION
The warning:
alphabase/alphabase/quantification/quant_reader/table_reformatter.py:75: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call

result.infer_objects(copy=False) instead. To opt-in to the future behavior, set
    return df[columns[0]].fillna(nan).astype(str)

The fix: 
replace `return df[columns[0]].fillna("nan").astype(str)` by `return df[columns[0]].fillna("nan").infer_objects(copy=False).astype(str)`