### PR TITLE
feat: add ion mobility column mapping to MSFragger PSM TSV reader

### DIFF
--- a/alphabase/constants/const_files/psm_reader.yaml
+++ b/alphabase/constants/const_files/psm_reader.yaml
@@ -231,6 +231,7 @@ msfragger_psm_tsv:
     'precursor_mz': 'Observed M/Z'
     '_tmp_mods': 'Assigned Modifications'
     'intensity': 'Intensity'
+    'mobility': 'Ion Mobility'
   mass_mapped_mods:
     - 'Oxidation@M'
     - 'Carbamidomethyl@C'


### PR DESCRIPTION
## Summary
- Add 'Ion Mobility' column mapping to msfragger_psm_tsv reader configuration
- Enables parsing of ion mobility values from TimsTOF data in MSFragger psm.tsv output