### PR TITLE
Register all modifications for msfragger reader

### DIFF
--- a/alphabase/constants/const_files/modification.tsv
+++ b/alphabase/constants/const_files/modification.tsv
@@ -265,12 +265,12 @@ GG@C	114.042927	114.1026	H(6)C(4)N(2)O(2)	0.0		Other	121	NCC(=O)NCC(=O)SC[C@H](N
 GG@T	114.042927	114.1026	H(6)C(4)N(2)O(2)	0.0		Other	121	NCC(=O)NCC(=O)O[C@H](C)[C@@H](C(=O)[Ts])N([Fl])([Fl])	0.0
 GG@S	114.042927	114.1026	H(6)C(4)N(2)O(2)	0.0		Other	121	NCC(=O)NCC(=O)OC[C@@H](C(=O)[Ts])N([Fl])([Fl])	0.0
 GG@K	114.042927	114.1026	H(6)C(4)N(2)O(2)	0.0		Other	121	NCC(=O)NCC(=O)NCCCC[C@H](N([Fl])([Fl]))C([Ts])=O	1000000.0
-GG@Protein_N-term	114.042927	114.1026	H(6)C(4)N(2)O(2)	0.0		Post-translational	121	NCC(=O)NCC(=O)[Ts]	0.0
-GG@Any_N-term	114.042927	114.1026	H(6)C(4)N(2)O(2)	0.0		Multiple	121	NCC(=O)NCC(=O)[Ts]	0.0
-Formyl@Protein_N-term	27.994915	28.0101	C(1)O(1)	0.0		Post-translational	122	O=C[Ts]	0.0
+GG@Protein_N-term	114.042927	114.1026	H(6)C(4)N(2)O(2)	0.0		Post-translational	121	NCC(=O)NCC(=O)[Lv]	0.0
+GG@Any_N-term	114.042927	114.1026	H(6)C(4)N(2)O(2)	0.0		Multiple	121	NCC(=O)NCC(=O)[Lv]	0.0
+Formyl@Protein_N-term	27.994915	28.0101	C(1)O(1)	0.0		Post-translational	122	O=C[Lv]	0.0
 Formyl@T	27.994915	28.0101	C(1)O(1)	0.0		Artefact	122		0.0
 Formyl@K	27.994915	28.0101	C(1)O(1)	0.0		Artefact	122	O=CNCCCC[C@H](N([Fl])([Fl]))C(=O)[Ts]	0.0
-Formyl@Any_N-term	27.994915	28.0101	C(1)O(1)	0.0		Artefact	122	O=C[Ts]	0.0
+Formyl@Any_N-term	27.994915	28.0101	C(1)O(1)	0.0		Artefact	122	O=C[Lv]	0.0
 Formyl@S	27.994915	28.0101	C(1)O(1)	0.0		Artefact	122		0.0
 ICAT-H@C	345.097915	345.7754	H(20)C(15)N(1)O(6)Cl(1)	0.0		Isotopic label	123		0.0
 ICAT-H:13C(6)@C	351.118044	351.7313	H(20)C(9)13C(6)N(1)O(6)Cl(1)	0.0		Isotopic label	124		0.0
@@ -352,8 +352,8 @@ NBS:13C(6)@W	159.008578	159.1144	H(3)13C(6)N(1)O(2)S(1)	0.0		Chemical derivative
 Methyl:2H(3)13C(1)@K	18.037835	18.0377	H(-1)2H(3)13C(1)	0.0		Isotopic label	329		0.0
 Methyl:2H(3)13C(1)@R	18.037835	18.0377	H(-1)2H(3)13C(1)	0.0		Isotopic label	329		0.0
 Methyl:2H(3)13C(1)@Any_N-term	18.037835	18.0377	H(-1)2H(3)13C(1)	0.0		Isotopic label	329		0.0
-Dimethyl:2H(6)13C(2)@Protein_N-term	36.07567	36.0754	H(-2)2H(6)13C(2)	0.0		Isotopic label	330	[13C]([2H])([2H])([2H])[Ts][13C]([2H])([2H])([2H])	0.0
-Dimethyl:2H(6)13C(2)@Any_N-term	36.07567	36.0754	H(-2)2H(6)13C(2)	0.0		Isotopic label	330	[13C]([2H])([2H])([2H])[Ts][13C]([2H])([2H])([2H])	0.0
+Dimethyl:2H(6)13C(2)@Protein_N-term	36.07567	36.0754	H(-2)2H(6)13C(2)	0.0		Isotopic label	330	[13C]([2H])([2H])([2H])[Lv][13C]([2H])([2H])([2H])	0.0
+Dimethyl:2H(6)13C(2)@Any_N-term	36.07567	36.0754	H(-2)2H(6)13C(2)	0.0		Isotopic label	330	[13C]([2H])([2H])([2H])[Lv][13C]([2H])([2H])([2H])	0.0
 Dimethyl:2H(6)13C(2)@R	36.07567	36.0754	H(-2)2H(6)13C(2)	0.0		Isotopic label	330		0.0
 Dimethyl:2H(6)13C(2)@K	36.07567	36.0754	H(-2)2H(6)13C(2)	0.0		Isotopic label	330	[13C]([2H])([2H])([2H])N([13C]([2H])([2H])([2H]))CCCC[C@H](N([Fl])([Fl]))C(=O)[Ts]	0.0
 NBS@W	152.988449	153.1585	H(3)C(6)N(1)O(2)S(1)	0.0		Chemical derivative	172		0.0
@@ -379,8 +379,8 @@ QAT:2H(3)@C	174.168569	174.2784	H(16)2H(3)C(9)N(2)O(1)	0.0		Isotopic label	196		
 Label:18O(2)@Any_C-term	4.008491	3.9995	O(-2)18O(2)	0.0		Isotopic label	193		0.0
 AccQTag@Any_N-term	170.048013	170.1674	H(6)C(10)N(2)O(1)	0.0		Chemical derivative	194		0.0
 AccQTag@K	170.048013	170.1674	H(6)C(10)N(2)O(1)	0.0		Chemical derivative	194		0.0
-Dimethyl:2H(4)@Protein_N-term	32.056407	32.0778	2H(4)C(2)	0.0		Isotopic label	199	C([2H])([2H])[Ts]C([2H])([2H])	0.0
-Dimethyl:2H(4)@Any_N-term	32.056407	32.0778	2H(4)C(2)	0.0		Isotopic label	199	C([2H])([2H])[Ts]C([2H])([2H])	0.0
+Dimethyl:2H(4)@Protein_N-term	32.056407	32.0778	2H(4)C(2)	0.0		Isotopic label	199	C([2H])([2H])[Lv]C([2H])([2H])	0.0
+Dimethyl:2H(4)@Any_N-term	32.056407	32.0778	2H(4)C(2)	0.0		Isotopic label	199	C([2H])([2H])[Lv]C([2H])([2H])	0.0
 Dimethyl:2H(4)@K	32.056407	32.0778	2H(4)C(2)	0.0		Isotopic label	199	C([2H])([2H])N(C([2H])([2H]))CCCC[C@H](N([Fl])([Fl]))C(=O)[Ts]	0.0
 Dimethyl:2H(4)@R	32.056407	32.0778	2H(4)C(2)	0.0		Isotopic label	199		0.0
 EQAT@C	184.157563	184.2786	H(20)C(10)N(2)O(1)	0.0		Chemical derivative	197		0.0
@@ -762,10 +762,10 @@ Diethyl@Any_N-term	56.0626	56.1063	H(8)C(4)	0.0		Chemical derivative	518		0.0
 Diethyl@K	56.0626	56.1063	H(8)C(4)	0.0		Chemical derivative	518		0.0
 LG-Hlactam-K@Protein_N-term	348.193674	348.4333	H(28)C(20)O(5)	0.0		Post-translational	504		0.0
 LG-Hlactam-K@K	348.193674	348.4333	H(28)C(20)O(5)	0.0		Post-translational	504		0.0
-Dimethyl:2H(4)13C(2)@Protein_N-term	34.063117	34.0631	2H(4)13C(2)	0.0		Isotopic label	510	[13C]([2H])([2H])([1H])[Ts][13C]([2H])([2H])([1H])	0.0
+Dimethyl:2H(4)13C(2)@Protein_N-term	34.063117	34.0631	2H(4)13C(2)	0.0		Isotopic label	510	[13C]([2H])([2H])([1H])[Lv][13C]([2H])([2H])([1H])	0.0
 Dimethyl:2H(4)13C(2)@R	34.063117	34.0631	2H(4)13C(2)	0.0		Isotopic label	510		0.0
 Dimethyl:2H(4)13C(2)@K	34.063117	34.0631	2H(4)13C(2)	0.0		Isotopic label	510	[13C]([2H])([2H])([1H])N([13C]([2H])([2H])([1H]))CCCC[C@H](N([Fl])([Fl]))C(=O)[Ts]	0.0
-Dimethyl:2H(4)13C(2)@Any_N-term	34.063117	34.0631	2H(4)13C(2)	0.0		Isotopic label	510	[13C]([2H])([2H])([1H])[Ts][13C]([2H])([2H])([1H])	0.0
+Dimethyl:2H(4)13C(2)@Any_N-term	34.063117	34.0631	2H(4)13C(2)	0.0		Isotopic label	510	[13C]([2H])([2H])([1H])[Lv][13C]([2H])([2H])([1H])	0.0
 C8-QAT@Any_N-term	227.224915	227.3862	H(29)C(14)N(1)O(1)	0.0		Chemical derivative	513		0.0
 C8-QAT@K	227.224915	227.3862	H(29)C(14)N(1)O(1)	0.0		Chemical derivative	513		0.0
 Hex(2)@R	324.105647	324.2812	H(20)C(12)O(10)	0.0		Other glycosylation	512		0.0
@@ -1591,7 +1591,7 @@ Dicarbamidomethyl@C	114.042927	114.1026	H(6)C(4)N(2)O(2)	0.0		Artefact	1290		0.0
 Dicarbamidomethyl@R	114.042927	114.1026	H(6)C(4)N(2)O(2)	0.0		Artefact	1290		0.0
 Dicarbamidomethyl@Any_N-term	114.042927	114.1026	H(6)C(4)N(2)O(2)	0.0		Artefact	1290		0.0
 Dimethyl:2H(6)@K	34.068961	34.0901	H(-2)2H(6)C(2)	0.0		Isotopic label	1291	C([2H])([2H])([2H])N(C([2H])([2H])([2H]))CCCC[C@H](N([Fl])([Fl]))C(=O)[Ts]	0.0
-Dimethyl:2H(6)@Any_N-term	34.068961	34.0901	H(-2)2H(6)C(2)	0.0		Isotopic label	1291	C([2H])([2H])([2H])[Ts]C([2H])([2H])([2H])	0.0
+Dimethyl:2H(6)@Any_N-term	34.068961	34.0901	H(-2)2H(6)C(2)	0.0		Isotopic label	1291	C([2H])([2H])([2H])[Lv]C([2H])([2H])([2H])	0.0
 Dimethyl:2H(6)@R	34.068961	34.0901	H(-2)2H(6)C(2)	0.0		Isotopic label	1291		0.0
 GGQ@K	242.101505	242.2319	H(14)C(9)N(4)O(4)	0.0		Other	1292		0.0
 QTGG@K	343.149184	343.3357	H(21)C(13)N(5)O(6)	0.0		Other	1293		0.0
@@ -2848,8 +2848,8 @@ iTRAQ4plex117@C	144.102063	144.1544	H(12)C(4)13C(3)N(1)15N(1)O(1)	0.0		Isotopic 
 PSMtag@K	308.116092	308.3359	C(18)H(16)N(2)O(3)	0.0		Chemical derivative	0	COC1N=CC(C2C=C3C(CN(C(C)=O)C3=CC=2)CC(=O)NCCCC[C@H](N([Fl])([Fl]))C(=O)[Ts])=CC=1	0.0
 PSMtag@Any_N-term	308.116092	308.3359	C(18)H(16)N(2)O(3)	0.0		Chemical derivative	0	COC1N=CC(C2C=C3C(CN(C(C)=O)C3=CC=2)CC(=O)[Lv])=CC=1	0.0
 Lactyl@K	72.021129	72.0627	H(4)C(3)O(2)	0.0		Post-translational	0	C[C@@H](O)C(=O)NCCCC[C@H](N([Fl])([Fl]))C(=O)[Ts]	0.0
-Lactyl@Any_N-term	72.021129	72.0627	H(4)C(3)O(2)	0.0		Post-translational	0	C[C@@H](O)C(=O)[Ts]	0.0
-Lactyl@Protein_N-term	72.021129	72.0627	H(4)C(3)O(2)	0.0		Post-translational	0	C[C@@H](O)C(=O)[Ts]	0.0
+Lactyl@Any_N-term	72.021129	72.0627	H(4)C(3)O(2)	0.0		Post-translational	0	C[C@@H](O)C(=O)[Lv]	0.0
+Lactyl@Protein_N-term	72.021129	72.0627	H(4)C(3)O(2)	0.0		Post-translational	0	C[C@@H](O)C(=O)[Lv]	0.0
 YnLactyl@K	239.126991	239.2941	H(17)C(11)N(3)O(3)	0.0		Post-translational	0	OCCCCCCN1C=C(C[C@@H](O)C(=O)NCCCC[C@H](N([Fl])([Fl]))C(=O)[Ts])N=N1	0.0
-YnLactyl@Any_N-term	239.126991	239.2941	H(17)C(11)N(3)O(3)	0.0		Post-translational	0	OCCCCCCN1C=C(C[C@@H](O)C(=O)[Ts])N=N1	0.0
-YnLactyl@Protein_N-term	239.126991	239.2941	H(17)C(11)N(3)O(3)	0.0		Post-translational	0	OCCCCCCN1C=C(C[C@@H](O)C(=O)[Ts])N=N1	0.0
+YnLactyl@Any_N-term	239.126991	239.2941	H(17)C(11)N(3)O(3)	0.0		Post-translational	0	OCCCCCCN1C=C(C[C@@H](O)C(=O)[Lv])N=N1	0.0
+YnLactyl@Protein_N-term	239.126991	239.2941	H(17)C(11)N(3)O(3)	0.0		Post-translational	0	OCCCCCCN1C=C(C[C@@H](O)C(=O)[Lv])N=N1	0.0

--- a/alphabase/constants/const_files/psm_reader.yaml
+++ b/alphabase/constants/const_files/psm_reader.yaml
@@ -317,8 +317,6 @@ modification_mappings:
       - 'T(229.1629)'
     'TMT6plex@H':
       - 'H(229.1629)'
-    'TMT6plex@Y':
-      - 'Y(229.1629)'
     'iTRAQ4plex@K':
       - 'K(144.1020)'
     'iTRAQ4plex@Any_N-term':
@@ -495,7 +493,6 @@ msfragger_psm_tsv:
     - 'TMT6plex@S'
     - 'TMT6plex@T'
     - 'TMT6plex@H'
-    - 'TMT6plex@Y'
     - 'TMTpro@K'
     - 'TMTpro@Any_N-term'
     - 'PSMtag@K'

--- a/tests/unit/psm_reader/test_msfragger_modification_translation.py
+++ b/tests/unit/psm_reader/test_msfragger_modification_translation.py
@@ -257,7 +257,7 @@ def test_msfragger_mod_masses_truncated_to_four_decimals():
     import re
 
     msfragger_mods = psm_reader_yaml["modification_mappings"]["msfragger"]
-    mass_pattern = re.compile(r"\((\d+\.\d+)\)")
+    mass_pattern = re.compile(r"\((-?\d+\.\d+)\)")
 
     for mod_name, mappings in msfragger_mods.items():
         for mapping in mappings if isinstance(mappings, list) else [mappings]:


### PR DESCRIPTION
This is not very elegant but the current way of operations. I suggest to move entirely to mass based mods, always match the closest within limits and then just using the explicit mapping for overrides or psm files which do not support mass based mapping.