### PR TITLE
Document MSFragger mass truncation convention

### DIFF
--- a/alphabase/constants/const_files/psm_reader.yaml
+++ b/alphabase/constants/const_files/psm_reader.yaml
@@ -162,7 +162,7 @@ modification_mappings:
     'Phospho@T': 'pT'
     'Phospho@Y': 'pY'
     'Acetyl@Protein_N-term': 'a'
-  # MSFragger modification masses are truncated (not rounded) to 4 decimal places (e.g., 79.9663 not 79.9664)
+  # MSFragger modification masses are truncated (not rounded) to 4 decimal places with explicit zeros
   msfragger:
     'SATA@K':
       - 'K(115.9932)'


### PR DESCRIPTION
## Summary
- Add comment in `psm_reader.yaml` explaining that MSFragger modification masses are truncated (not rounded) to 4 decimal places with explicit zeros

🤖 Generated with [Claude Code](https://claude.com/claude-code)