### PR TITLE
Fix spectronaut reader mapping

### DIFF
--- a/alphabase/constants/const_files/psm_reader.yaml
+++ b/alphabase/constants/const_files/psm_reader.yaml
@@ -162,41 +162,6 @@ modification_mappings:
     'Phospho@T': 'pT'
     'Phospho@Y': 'pY'
     'Acetyl@Protein_N-term': 'a'
-  msfragger:
-    'SATA@K':
-      - 'K(115.9932)'
-    'SATA@Any_N-term':
-      - 'N-term(115.9932)'
-    'SATA-Succinamide@K':
-      - 'K(247.0150)'
-    'SATA-Succinamide@Any_N-term':
-      - 'N-term(247.0150)'
-    'SATP@K':
-      - 'K(130.0088)'
-    'SATP@Any_N-term':
-      - 'N-term(130.0088)'
-    'SATP-Succinamide@K':
-      - 'K(261.0307)'
-    'SATP-Succinamide@Any_N-term':
-      - 'N-term(261.0307)'
-    'Acetyl@K':
-      - 'K(42.0105)'
-    'mTRAQ@K':
-      - 'K(140.0949)'
-    'mTRAQ@Any_N-term':
-      - 'N-term(140.0949)'
-    'mTRAQ:13C(3)15N(1)@K':
-      - 'K(144.1020)'
-    'mTRAQ:13C(3)15N(1)@Any_N-term':
-      - 'N-term(144.1020)'
-    'mTRAQ:13C(6)15N(2)@K':
-      - 'K(148.1091)'
-    'mTRAQ:13C(6)15N(2)@Any_N-term':
-      - 'N-term(148.1091)'
-    'TMTpro@K':
-      - 'K(304.2071)'
-    'TMTpro@Any_N-term':
-      - 'N-term(304.2071)'
 
 pfind:
   reader_type: pfind
@@ -246,7 +211,7 @@ msfragger_psm_tsv:
     - 'TMTpro@K'
     - 'TMTpro@Any_N-term'
   mod_mass_tol: 0.1
-  modification_mapping_type: 'msfragger'
+  modification_mapping_type: 'maxquant'
 
 msfragger_pepxml:
   reader_type: msfragger_pepxml
@@ -314,16 +279,21 @@ spectronaut_report:
   fixed_C57: False
   column_mapping:
     'raw_name': 'R.FileName'
+    'sequence': 'PEP.StrippedSequence'
+    'charge': ['charge', 'FG.Charge']
     'rt': ['EG.ApexRT','EG.MeanApexRT']
-    'mobility': ['FG.ApexIonMobility']
-    'proteins': ['PG.ProteinNames','PG.ProteinGroups']
-    'genes': 'PG.Genes'
+    'mobility': 'FG.ApexIonMobility'
+    'proteins': ['PG.ProteinNames','PG.ProteinGroups', 'PG.ProteinAccessions']
+    'precursor_mz': 'FG.PrecMz'
     'uniprot_ids': 'PG.UniProtIds'
-    'charge': 'charge'
+    'genes': ['PG.Genes', 'PG.ProteinNames']
+    'fdr': 'EG.Qvalue'
+    'intensity': 'PG.Quantity'
+    'precursor_id': 'EG.PrecursorId'
+    'precursor_intensity': 'EG.TotalQuantity (Settings)'
+
   mod_seq_columns:
     - 'ModifiedSequence'
-  precursor_id_columns:
-    - "EG.PrecursorId"
   modification_mapping_type: 'maxquant'
 
 spectronaut:
@@ -335,12 +305,14 @@ spectronaut:
     'sequence': ['StrippedPeptide','PeptideSequence']
     'charge': 'PrecursorCharge'
     'rt': ['RT','iRT','Tr_recalibrated','RetentionTime','NormalizedRetentionTime']
-    'ccs': 'CCS'
-    'precursor_mz': 'PrecursorMz'
     'mobility': ['Mobility','IonMobility','PrecursorIonMobility']
     'proteins': ['Protein Name','ProteinId','ProteinID','ProteinName','ProteinGroup','ProteinGroups']
+    'ccs': 'CCS'
+    'precursor_mz': 'PrecursorMz'
     'uniprot_ids': ['UniProtIds','UniProtID','UniprotId']
     'genes': ['Genes','Gene','GeneName','GeneNames']
+    'precursor_id': "EG.PrecursorId"
+
   mod_seq_columns:
     - 'ModifiedPeptide'
     - 'ModifiedSequence'
@@ -348,8 +320,6 @@ spectronaut:
     - 'ModifiedPeptideSequence'
     - 'LabeledSequence'
     - 'FullUniModPeptideName'
-  precursor_id_columns:
-    - "EG.PrecursorId"
   modification_mapping_type: 'maxquant'
 
 library_reader_base:

--- a/alphabase/constants/const_files/psm_reader.yaml
+++ b/alphabase/constants/const_files/psm_reader.yaml
@@ -280,8 +280,8 @@ spectronaut_report:
   column_mapping:
     'raw_name': 'R.FileName'
     'sequence': 'PEP.StrippedSequence'
-    'charge': ['charge', 'FG.Charge']
     'rt': ['EG.ApexRT','EG.MeanApexRT']
+    'charge': ['charge', 'FG.Charge']
     'mobility': 'FG.ApexIonMobility'
     'proteins': ['PG.ProteinNames','PG.ProteinGroups', 'PG.ProteinAccessions']
     'precursor_mz': 'FG.PrecMz'
@@ -307,10 +307,10 @@ spectronaut:
     'sequence': ['StrippedPeptide','PeptideSequence']
     'charge': 'PrecursorCharge'
     'rt': ['RT','iRT','Tr_recalibrated','RetentionTime','NormalizedRetentionTime']
+    'precursor_mz': 'PrecursorMz'
     'mobility': ['Mobility','IonMobility','PrecursorIonMobility']
     'proteins': ['Protein Name','ProteinId','ProteinID','ProteinName','ProteinGroup','ProteinGroups']
     'ccs': 'CCS'
-    'precursor_mz': 'PrecursorMz'
     'uniprot_ids': ['UniProtIds','UniProtID','UniprotId']
     'genes': ['Genes','Gene','GeneName','GeneNames']
 

--- a/alphabase/constants/const_files/psm_reader.yaml
+++ b/alphabase/constants/const_files/psm_reader.yaml
@@ -288,13 +288,15 @@ spectronaut_report:
     'uniprot_ids': 'PG.UniProtIds'
     'genes': ['PG.Genes', 'PG.ProteinNames']
     'fdr': 'EG.Qvalue'
-    'intensity': 'PG.Quantity'
-    'precursor_id': 'EG.PrecursorId'
+    'intensity': 'EG.TotalQuantity (Settings)'
     'precursor_intensity': 'EG.TotalQuantity (Settings)'
 
   mod_seq_columns:
     - 'ModifiedSequence'
+    - 'EG.PrecursorId'
   modification_mapping_type: 'maxquant'
+  precursor_id_columns:
+    - "EG.PrecursorId"
 
 spectronaut:
   reader_type: spectronaut
@@ -311,7 +313,6 @@ spectronaut:
     'precursor_mz': 'PrecursorMz'
     'uniprot_ids': ['UniProtIds','UniProtID','UniprotId']
     'genes': ['Genes','Gene','GeneName','GeneNames']
-    'precursor_id': "EG.PrecursorId"
 
   mod_seq_columns:
     - 'ModifiedPeptide'
@@ -321,6 +322,8 @@ spectronaut:
     - 'LabeledSequence'
     - 'FullUniModPeptideName'
   modification_mapping_type: 'maxquant'
+  precursor_id_columns:
+    - "EG.PrecursorId"
 
 library_reader_base:
   reader_type: library_reader_base

--- a/alphabase/constants/const_files/psm_reader.yaml
+++ b/alphabase/constants/const_files/psm_reader.yaml
@@ -162,6 +162,41 @@ modification_mappings:
     'Phospho@T': 'pT'
     'Phospho@Y': 'pY'
     'Acetyl@Protein_N-term': 'a'
+  msfragger:
+    'SATA@K':
+      - 'K(115.9932)'
+    'SATA@Any_N-term':
+      - 'N-term(115.9932)'
+    'SATA-Succinamide@K':
+      - 'K(247.0150)'
+    'SATA-Succinamide@Any_N-term':
+      - 'N-term(247.0150)'
+    'SATP@K':
+      - 'K(130.0088)'
+    'SATP@Any_N-term':
+      - 'N-term(130.0088)'
+    'SATP-Succinamide@K':
+      - 'K(261.0307)'
+    'SATP-Succinamide@Any_N-term':
+      - 'N-term(261.0307)'
+    'Acetyl@K':
+      - 'K(42.0105)'
+    'mTRAQ@K':
+      - 'K(140.0949)'
+    'mTRAQ@Any_N-term':
+      - 'N-term(140.0949)'
+    'mTRAQ:13C(3)15N(1)@K':
+      - 'K(144.1020)'
+    'mTRAQ:13C(3)15N(1)@Any_N-term':
+      - 'N-term(144.1020)'
+    'mTRAQ:13C(6)15N(2)@K':
+      - 'K(148.1091)'
+    'mTRAQ:13C(6)15N(2)@Any_N-term':
+      - 'N-term(148.1091)'
+    'TMTpro@K':
+      - 'K(304.2071)'
+    'TMTpro@Any_N-term':
+      - 'N-term(304.2071)'
 
 pfind:
   reader_type: pfind
@@ -211,7 +246,7 @@ msfragger_psm_tsv:
     - 'TMTpro@K'
     - 'TMTpro@Any_N-term'
   mod_mass_tol: 0.1
-  modification_mapping_type: 'maxquant'
+  modification_mapping_type: 'msfragger'
 
 msfragger_pepxml:
   reader_type: msfragger_pepxml
@@ -290,7 +325,6 @@ spectronaut_report:
     'fdr': 'EG.Qvalue'
     'intensity': 'EG.TotalQuantity (Settings)'
     'precursor_intensity': 'EG.TotalQuantity (Settings)'
-
   mod_seq_columns:
     - 'ModifiedSequence'
     - 'EG.PrecursorId'
@@ -307,13 +341,12 @@ spectronaut:
     'sequence': ['StrippedPeptide','PeptideSequence']
     'charge': 'PrecursorCharge'
     'rt': ['RT','iRT','Tr_recalibrated','RetentionTime','NormalizedRetentionTime']
+    'ccs': 'CCS'
     'precursor_mz': 'PrecursorMz'
     'mobility': ['Mobility','IonMobility','PrecursorIonMobility']
     'proteins': ['Protein Name','ProteinId','ProteinID','ProteinName','ProteinGroup','ProteinGroups']
-    'ccs': 'CCS'
     'uniprot_ids': ['UniProtIds','UniProtID','UniprotId']
     'genes': ['Genes','Gene','GeneName','GeneNames']
-
   mod_seq_columns:
     - 'ModifiedPeptide'
     - 'ModifiedSequence'
@@ -321,9 +354,9 @@ spectronaut:
     - 'ModifiedPeptideSequence'
     - 'LabeledSequence'
     - 'FullUniModPeptideName'
-  modification_mapping_type: 'maxquant'
   precursor_id_columns:
     - "EG.PrecursorId"
+  modification_mapping_type: 'maxquant'
 
 library_reader_base:
   reader_type: library_reader_base

--- a/alphabase/psm_reader/dia_psm_reader.py
+++ b/alphabase/psm_reader/dia_psm_reader.py
@@ -126,9 +126,11 @@ class SpectronautReportReader(ModifiedSequenceReader):
 
     def _pre_process(self, df: pd.DataFrame) -> pd.DataFrame:
         """Spectronaut report-specific preprocessing of output data."""
-        df[[self.mod_seq_column, PsmDfCols.CHARGE]] = df[
-            self._precursor_id_column
-        ].str.split(".", expand=True, n=2)
+        # In case charge state column is missing, we splice it out of the precursor id column
+        if PsmDfCols.CHARGE not in df.columns:
+            df[[self.mod_seq_column, PsmDfCols.CHARGE]] = df[
+                self._precursor_id_column
+            ].str.split(".", expand=True, n=2)
         df[PsmDfCols.CHARGE] = df[PsmDfCols.CHARGE].astype(np.int8)
         return df
 


### PR DESCRIPTION
### Reasons for the PR:
- Reading Spectronaut reports from versions 20.0.250515.50606 and 20.0.250515.50606 failed with the `spectronaut_report` reader config due to missing columns (intensity, precursor_intensity). 
- `_pre_process()` tried to parse charge out of non-existent columns (`ModifiedSequence`)

### The issues
- Some columns that are present in these report files were not covered by the reader config (FG.PrecMz for `charge`, PG.ProteinNames for `genes`). 
- The `_preprocess()` method tried to parse charge from the mod_seq_column "ModifiedSequence", which does not exist in these reports. 

### The fixes
- Extend `spectronaut_report` configuration to parse additional columns correctly
- Add `EG.PrecursorId` to `mod_seq_columns` to get charge information in case `FG.PrecMz` is missing
- Modify `_pre_process()` to first check whether the charge column is present and only then parse it from the `precursor_id` column

