### PR TITLE
fix missing decoy column

### DIFF
--- a/alphabase/psm_reader/msfragger_reader.py
+++ b/alphabase/psm_reader/msfragger_reader.py
@@ -426,9 +426,12 @@ class MSFraggerPsmTsvReader(PSMReaderBase):
         return df
 
     def _translate_decoy(self) -> None:
+        # if the decoy column deosnt exist we assume all entries are target
         self._psm_df[PsmDfCols.DECOY] = (
-            self._psm_df[PsmDfCols.DECOY] == "true"
-        ).astype(np.int8)
+            0
+            if PsmDfCols.DECOY not in self._psm_df.columns
+            else (self._psm_df[PsmDfCols.DECOY] == "true").astype(np.int8)
+        )
 
     def _translate_score(self) -> None:
         """MSFragger Hyperscore is already in correct format (larger = better)."""

--- a/tests/unit/psm_reader/test_msfragger_psm_tsv.py
+++ b/tests/unit/psm_reader/test_msfragger_psm_tsv.py
@@ -68,6 +68,13 @@ class TestDataProcessing:
         reader._translate_decoy()
         assert reader._psm_df[PsmDfCols.DECOY].tolist() == [1, 0]
 
+    def test_decoy_translation_no_column(self, reader):
+        """Test decoy translation when decoy column is missing."""
+        reader._psm_df = pd.DataFrame({"Peptide": ["PEPTIDE", "SEQUENCE"]})
+        reader._translate_decoy()
+        assert PsmDfCols.DECOY in reader._psm_df.columns
+        assert reader._psm_df[PsmDfCols.DECOY].tolist() == [0, 0]
+
     def test_modification_loading_integration(self, reader):
         """Test modification loading produces complete correct results."""
         # Simulates what happens after _translate_columns() maps the column


### PR DESCRIPTION
<!--
  Briefly describe the changes your PR makes.
  Include any info that might be relevant for reviewers to understand the context.
-->

Fix the case where the 'Is Decoy' column doesnt exist in psm.tsv by assuming all are target


---

#### To-do list (outside contributers only)
- [ ] I have read and agree to the [MannLabs Contributor License Agreement](https://github.com/MannLabs/.github/blob/main/CLA.md)