### PR TITLE
[Fix] Fix incorrect pytest skip usage that raises in error in pytest>9

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -141,7 +141,6 @@ sp|P35221|CTNA1_HUMAN,225968334.02204236,234103031.64081344,221399683.34428945,2
     return file_path, reference
 
 
-@pytest.mark.optional_pytables_dependency
 @pytest.fixture(scope="function")
 def example_alphapept_hdf(tmp_path) -> tuple[Path, pd.DataFrame]:
     """Get and parse real alphapept protein group report matrix."""


### PR DESCRIPTION
Fixes incorrect usage of `pytest.mark` together `pytest.fixture` in the PG reader integration tests 

Marking fixtures with `pytest.mark` has no effect (as fixtures are only called if tests that depend on them are called). Previously, this raised a warning, but since `pytest==9.0`, this pattern raises an error and makes the protein group reader integration tests fail.

See: https://docs.pytest.org/en/stable/changelog.html#pytest-9-0-2-2025-12-06