### PR TITLE
Add PSMtag modifications for S, T, and Y

### DIFF
--- a/alphabase/constants/const_files/modification.tsv
+++ b/alphabase/constants/const_files/modification.tsv
@@ -2849,6 +2849,8 @@ iTRAQ4plex117@K	144.102063	144.1544	H(12)C(4)13C(3)N(1)15N(1)O(1)	0.0		Isotopic 
 iTRAQ4plex117@C	144.102063	144.1544	H(12)C(4)13C(3)N(1)15N(1)O(1)	0.0		Isotopic label	0	C[15N]1[13CH2][13CH2]N(CC1)[13CH2]C(=O)SC[C@@H](C(=O)[Ts])N([Fl])([Fl])	0.0
 PSMtag@K	308.116092	308.3359	C(18)H(16)N(2)O(3)	0.0		Chemical derivative	0	COC1N=CC(C2C=C3C(CN(C(C)=O)C3=CC=2)CC(=O)NCCCC[C@H](N([Fl])([Fl]))C(=O)[Ts])=CC=1	0.0
 PSMtag@S	308.116092	308.3359	C(18)H(16)N(2)O(3)	0.0		Chemical derivative	0	COC1N=CC(C2C=C3C(CN(C(C)=O)C3=CC=2)CC(=O)OC[C@H](N([Fl])([Fl]))C(=O)[Ts])=CC=1	0.0
+PSMtag@T	308.116092	308.3359	C(18)H(16)N(2)O(3)	0.0		Chemical derivative	0	COC1N=CC(C2C=C3C(CN(C(C)=O)C3=CC=2)CC(=O)O[C@H](C)[C@@H](N([Fl])([Fl]))C(=O)[Ts])=CC=1	0.0
+PSMtag@Y	308.116092	308.3359	C(18)H(16)N(2)O(3)	0.0		Chemical derivative	0	COC1N=CC(C2C=C3C(CN(C(C)=O)C3=CC=2)CC(=O)Oc4ccc(C[C@@H](C(=O)[Ts])N([Fl])([Fl]))cc4)=CC=1	0.0
 PSMtag@Any_N-term	308.116092	308.3359	C(18)H(16)N(2)O(3)	0.0		Chemical derivative	0	COC1N=CC(C2C=C3C(CN(C(C)=O)C3=CC=2)CC(=O)[Lv])=CC=1	0.0
 Lactyl@K	72.021129	72.0627	H(4)C(3)O(2)	0.0		Post-translational	0	C[C@@H](O)C(=O)NCCCC[C@H](N([Fl])([Fl]))C(=O)[Ts]	0.0
 Lactyl@Any_N-term	72.021129	72.0627	H(4)C(3)O(2)	0.0		Post-translational	0	C[C@@H](O)C(=O)[Lv]	0.0

--- a/alphabase/constants/const_files/modification.tsv
+++ b/alphabase/constants/const_files/modification.tsv
@@ -2848,6 +2848,7 @@ iTRAQ4plex117@Any_N-term	144.102063	144.1544	H(12)C(4)13C(3)N(1)15N(1)O(1)	0.0		
 iTRAQ4plex117@K	144.102063	144.1544	H(12)C(4)13C(3)N(1)15N(1)O(1)	0.0		Isotopic label	0	[H]N(CCCC[C@H](N([Fl])([Fl]))C(=O)[Ts])C(=O)[13CH2][15N]1[13CH2][13CH2]N(C)CC1	0.0
 iTRAQ4plex117@C	144.102063	144.1544	H(12)C(4)13C(3)N(1)15N(1)O(1)	0.0		Isotopic label	0	C[15N]1[13CH2][13CH2]N(CC1)[13CH2]C(=O)SC[C@@H](C(=O)[Ts])N([Fl])([Fl])	0.0
 PSMtag@K	308.116092	308.3359	C(18)H(16)N(2)O(3)	0.0		Chemical derivative	0	COC1N=CC(C2C=C3C(CN(C(C)=O)C3=CC=2)CC(=O)NCCCC[C@H](N([Fl])([Fl]))C(=O)[Ts])=CC=1	0.0
+PSMtag@S	308.116092	308.3359	C(18)H(16)N(2)O(3)	0.0		Chemical derivative	0	COC1N=CC(C2C=C3C(CN(C(C)=O)C3=CC=2)CC(=O)OC[C@H](N([Fl])([Fl]))C(=O)[Ts])=CC=1	0.0
 PSMtag@Any_N-term	308.116092	308.3359	C(18)H(16)N(2)O(3)	0.0		Chemical derivative	0	COC1N=CC(C2C=C3C(CN(C(C)=O)C3=CC=2)CC(=O)[Lv])=CC=1	0.0
 Lactyl@K	72.021129	72.0627	H(4)C(3)O(2)	0.0		Post-translational	0	C[C@@H](O)C(=O)NCCCC[C@H](N([Fl])([Fl]))C(=O)[Ts]	0.0
 Lactyl@Any_N-term	72.021129	72.0627	H(4)C(3)O(2)	0.0		Post-translational	0	C[C@@H](O)C(=O)[Lv]	0.0

--- a/alphabase/constants/const_files/psm_reader.yaml
+++ b/alphabase/constants/const_files/psm_reader.yaml
@@ -376,6 +376,8 @@ modification_mappings:
       - 'N-term(145.1404)'
     'PSMtag@K':
       - 'K(308.1160)'
+    'PSMtag@S':
+      - 'S(308.1160)'
     'PSMtag@Any_N-term':
       - 'N-term(308.1160)'
     'Glc-TA@K':
@@ -503,6 +505,7 @@ msfragger_psm_tsv:
     - 'TMTpro@K'
     - 'TMTpro@Any_N-term'
     - 'PSMtag@K'
+    - 'PSMtag@S'
     - 'PSMtag@Any_N-term'
     - 'Dimethyl@K'
     - 'Dimethyl@Any_N-term'

--- a/alphabase/constants/const_files/psm_reader.yaml
+++ b/alphabase/constants/const_files/psm_reader.yaml
@@ -378,6 +378,10 @@ modification_mappings:
       - 'K(308.1160)'
     'PSMtag@S':
       - 'S(308.1160)'
+    'PSMtag@T':
+      - 'T(308.1160)'
+    'PSMtag@Y':
+      - 'Y(308.1160)'
     'PSMtag@Any_N-term':
       - 'N-term(308.1160)'
     'Glc-TA@K':
@@ -506,6 +510,8 @@ msfragger_psm_tsv:
     - 'TMTpro@Any_N-term'
     - 'PSMtag@K'
     - 'PSMtag@S'
+    - 'PSMtag@T'
+    - 'PSMtag@Y'
     - 'PSMtag@Any_N-term'
     - 'Dimethyl@K'
     - 'Dimethyl@Any_N-term'


### PR DESCRIPTION
## Summary
- Add PSMtag@S, PSMtag@T, and PSMtag@Y modifications to modification.tsv with SMILES structures
- Add MSFragger reader mappings for all three in psm_reader.yaml
- All use ester linkages to the hydroxyl groups (vs amide linkage for PSMtag@K)

🤖 Generated with [Claude Code](https://claude.com/claude-code)