### PR TITLE
PEAKStudio Empirical/Spectral library reader

### DIFF
--- a/alphabase/constants/const_files/psm_reader.yaml
+++ b/alphabase/constants/const_files/psm_reader.yaml
@@ -763,7 +763,6 @@ peaks_library:
     'precursor_mz': 'm/z'
     'rt': 'rt (seconds)'
     '_tmp_mods': 'Modifications'   # raw mod column, parsed in code (like MSFragger)
-    'peaks_list': 'Peaks List'     # packed fragment column, exploded in _load_file
     'fragment_mz': 'FragmentMz'
     'fragment_intensity': 'FragmentIntensity'
     'fragment_type': 'FragmentType'
@@ -772,6 +771,8 @@ peaks_library:
     'fragment_loss_type': 'FragmentLossType'
   mod_seq_columns:
     - 'Sequence (backbone)'
+  # packed per-precursor fragment column.
+  peaks_list_column: 'Peaks List'
   modification_mapping_type: null  # modifications resolved in code using mass and residue/terminus, not by name
   mod_mass_tol: 0.1
   # alphabase mod names the PEAKS "Modifications" column resolves to (matched by

--- a/alphabase/constants/const_files/psm_reader.yaml
+++ b/alphabase/constants/const_files/psm_reader.yaml
@@ -751,6 +751,7 @@ library_reader_base:
 # PEAKS Studio DIA library export (wide format: one row per precursor, all
 # fragments packed into a single "Peaks List" cell). PeaksLibraryReader explodes
 # it into the long format below before the standard library pipeline runs, and converts it to the dense SpeclibBase format.
+# Columns tested against PEAKS Studio 13.5.
 
 peaks_library:
   reader_type: peaks_library

--- a/alphabase/constants/const_files/psm_reader.yaml
+++ b/alphabase/constants/const_files/psm_reader.yaml
@@ -748,6 +748,38 @@ library_reader_base:
     - 'FullUniModPeptideName'
   modification_mapping_type: 'maxquant'
 
+# PEAKS Studio DIA library export (wide format: one row per precursor, all
+# fragments packed into a single "Peaks List" cell). PeaksLibraryReader explodes
+# it into the long format below before the standard library pipeline runs, and converts it to the dense SpeclibBase format.
+
+peaks_library:
+  reader_type: peaks_library
+  rt_unit: second
+  fixed_C57: False
+  column_mapping:
+    'sequence': 'Sequence (backbone)'
+    'modified_sequence': 'Sequence (backbone)'
+    'charge': 'z'
+    'precursor_mz': 'm/z'
+    'rt': 'rt (seconds)'
+    'fragment_mz': 'FragmentMz'
+    'fragment_intensity': 'FragmentIntensity'
+    'fragment_type': 'FragmentType'
+    'fragment_charge': 'FragmentCharge'
+    'fragment_series': 'FragmentNumber'
+    'fragment_loss_type': 'FragmentLossType'
+  mod_seq_columns:
+    - 'Sequence (backbone)'
+  modification_mapping_type: null  # modifications resolved in code using mass and residue/terminus, not by name
+  mod_mass_tol: 0.1
+  # alphabase mod names the PEAKS "Modifications" column resolves to (matched by
+  # mass + residue/terminus). A modification not listed here warns and its
+  # precursor is dropped; add it here to keep those precursors.
+  mass_mapped_mods:
+    - 'Carboxymethyl@C'         # 58.01
+    - 'Oxidation@M'             # 15.99
+    - 'Acetyl@Protein_N-term'   # 42.01
+
 sage:
   reader_type: sage
   rt_unit: second

--- a/alphabase/constants/const_files/psm_reader.yaml
+++ b/alphabase/constants/const_files/psm_reader.yaml
@@ -762,6 +762,8 @@ peaks_library:
     'charge': 'z'
     'precursor_mz': 'm/z'
     'rt': 'rt (seconds)'
+    '_tmp_mods': 'Modifications'   # raw mod column, parsed in code (like MSFragger)
+    'peaks_list': 'Peaks List'     # packed fragment column, exploded in _load_file
     'fragment_mz': 'FragmentMz'
     'fragment_intensity': 'FragmentIntensity'
     'fragment_type': 'FragmentType'

--- a/alphabase/constants/modification.py
+++ b/alphabase/constants/modification.py
@@ -62,6 +62,12 @@ class ModificationKeys(metaclass=_ConstantsClass):
     #: Protein C-terminus only
     PROTEIN_C_TERM: str = "Protein_C-term"
 
+    #: Suffix shared by all N-terminal sites ("Any_N-term", "Protein_N-term")
+    N_TERM: str = "N-term"
+
+    #: Suffix shared by all C-terminal sites ("Any_C-term", "Protein_C-term")
+    C_TERM: str = "C-term"
+
     #: AA-specific N-term suffix: "Gln->pyro-Glu@Q^Any_N-term" (Q at any N-term)
     ANY_N_TERM_SPECIFIC: str = "^Any_N-term"
 

--- a/alphabase/psm_reader/sage_reader.py
+++ b/alphabase/psm_reader/sage_reader.py
@@ -536,8 +536,12 @@ def _get_annotated_mod_df() -> pd.DataFrame:
     mod_annotated_df["localizer_rank"] = mod_annotated_df["previous_aa"].str.len()
     mod_annotated_df.loc[mod_annotated_df["localizer_rank"] > 1, "previous_aa"] = ""
 
-    mod_annotated_df["is_nterm"] = mod_annotated_df["mod_name"].str.contains("N-term")
-    mod_annotated_df["is_cterm"] = mod_annotated_df["mod_name"].str.contains("C-term")
+    mod_annotated_df["is_nterm"] = mod_annotated_df["mod_name"].str.contains(
+        ModificationKeys.N_TERM
+    )
+    mod_annotated_df["is_cterm"] = mod_annotated_df["mod_name"].str.contains(
+        ModificationKeys.C_TERM
+    )
 
     return mod_annotated_df[
         ["mass", "previous_aa", "is_nterm", "is_cterm", "unimod_id", "localizer_rank"]

--- a/alphabase/spectral_library/peaks_reader.py
+++ b/alphabase/spectral_library/peaks_reader.py
@@ -13,22 +13,9 @@ import numpy as np
 import pandas as pd
 
 from alphabase.constants.modification import MOD_MASS, ModificationKeys
-from alphabase.psm_reader.keys import PsmDfCols
+from alphabase.psm_reader.keys import LibPsmDfCols, PsmDfCols
 from alphabase.psm_reader.psm_reader import psm_reader_yaml
 from alphabase.spectral_library.reader import LibraryReaderBase
-
-# Column names in the raw PEAKS export.
-_PEAKS_SEQUENCE_COLUMN = "Sequence (backbone)"
-_PEAKS_MOD_COLUMN = "Modifications"
-_PEAKS_PEAKS_COLUMN = "Peaks List"
-
-# Internal (synthesized) long-format fragment column names, mapped in psm_reader.yaml.
-_FRAGMENT_MZ = "FragmentMz"
-_FRAGMENT_INTENSITY = "FragmentIntensity"
-_FRAGMENT_TYPE = "FragmentType"
-_FRAGMENT_CHARGE = "FragmentCharge"
-_FRAGMENT_NUMBER = "FragmentNumber"
-_FRAGMENT_LOSS_TYPE = "FragmentLossType"
 
 # A fragment annotation, e.g. 'b6', 'y13[2+]', 'b12-H2O', 'y5-NH3[3+]'.
 _FRAGMENT_ANNOTATION_PATTERN = re.compile(
@@ -87,56 +74,181 @@ def _parse_fragment_annotation(
     return frag_type, int(number), int(charge) if charge else 1, loss or ""
 
 
-def _match_mod_by_mass(
-    mass: float,
-    aa_or_term: str,
-    mass_mapped_mods: List[str],
-    mod_mass_tol: float,
-) -> Optional[str]:
-    """Resolve a PEAKS modification to an alphabase name by mass and residue/terminus.
+class PeaksModificationTranslator:
+    """Translate PEAKS ``Modifications`` cells to alphabase mods and mod_sites.
 
-    Parameters
-    ----------
-    mass : float
-        Mass shift from the PEAKS entry (e.g. 15.99).
-    aa_or_term : str
-        The amino acid at the modification site, or ``Any_N-term`` / ``Any_C-term``.
-    mass_mapped_mods : List[str]
-        Candidate alphabase mod names (e.g. ['Oxidation@M', 'Carboxymethyl@C']).
-    mod_mass_tol : float
-        Mass tolerance in Daltons.
-
-    Returns
-    -------
-    str or None
-        The matched alphabase modification name (e.g. 'Oxidation@M'), or ``None``
-        if no candidate matches the mass and residue/terminus within tolerance.
-
+    PEAKS encodes each modification as ``<0-based position>-<name>-(<mass>)``. This
+    resolves it to an alphabase name by mass + the residue read from the sequence
+    (terminal mods are recognised by 'N-term'/'C-term' in the name), matching against
+    a curated ``mass_mapped_mods`` list. Modifications not in the list mark their
+    precursor for removal.
     """
-    is_terminal = aa_or_term in (
-        ModificationKeys.ANY_N_TERM,
-        ModificationKeys.ANY_C_TERM,
-    )
-    term_keyword = "N-term" if aa_or_term == ModificationKeys.ANY_N_TERM else "C-term"
 
-    best_match = None
-    best_mass_diff = float("inf")
-    for mod_name in mass_mapped_mods:
-        if mod_name not in MOD_MASS:
-            continue
-        mass_diff = abs(mass - MOD_MASS[mod_name])
-        if mass_diff >= mod_mass_tol or mass_diff >= best_mass_diff:
-            continue
+    def __init__(self, mass_mapped_mods: List[str], mod_mass_tol: float):
+        """Store the candidate alphabase mod names and the mass tolerance (Da)."""
+        self._mass_mapped_mods = mass_mapped_mods
+        self._mod_mass_tol = mod_mass_tol
 
-        mod_site = mod_name.split(ModificationKeys.SITE_SEPARATOR)[1]
-        matches = (
-            mod_site.endswith(term_keyword) if is_terminal else mod_site == aa_or_term
+    def translate(
+        self, sequences: np.ndarray, mod_strings: np.ndarray
+    ) -> Tuple[list, list]:
+        """Translate PEAKS ``Modifications`` cells to alphabase mods and mod_sites.
+
+        Parameters
+        ----------
+        sequences : np.ndarray
+            Backbone sequences, one per precursor.
+        mod_strings : np.ndarray
+            The raw PEAKS ``Modifications`` cell for each precursor, parallel to
+            ``sequences``.
+
+        Returns
+        -------
+        tuple of (list, list)
+            ``(mods_list, mod_sites_list)``, one entry per precursor. A precursor
+            whose modifications cannot all be resolved gets ``NaN`` for both (so the
+            inherited ``_post_process`` drops it); the unresolved names are reported
+            together in a single warning.
+
+        """
+        cache = {}
+        unknown_mods: Set[str] = set()
+        mods_list = []
+        sites_list = []
+        for sequence, mod_str in zip(sequences, mod_strings):
+            key = (sequence, mod_str)
+            if key not in cache:
+                cache[key] = self._parse_cell(sequence, mod_str)
+            mods, sites, unknown = cache[key]
+            unknown_mods.update(unknown)
+            mods_list.append(mods if mods is not None else np.nan)
+            sites_list.append(sites if sites is not None else np.nan)
+
+        if unknown_mods:
+            warnings.warn(
+                f"Unknown PEAKS modifications: {sorted(unknown_mods)}. Precursors "
+                f"with these modifications will be removed. Add them to "
+                f"'mass_mapped_mods' for 'peaks_library' in psm_reader.yaml to keep them."
+            )
+        return mods_list, sites_list
+
+    def _parse_cell(
+        self, sequence: str, mod_str: str
+    ) -> Tuple[Optional[str], Optional[str], Set[str]]:
+        """Parse a single PEAKS ``Modifications`` cell.
+
+        Positions are 0-based indices into the backbone sequence; a mod whose name
+        contains 'N-term'/'C-term' is terminal regardless of position.
+
+        Parameters
+        ----------
+        sequence : str
+            The backbone sequence, used to look up the residue at each position.
+        mod_str : str
+            The raw PEAKS ``Modifications`` cell, e.g.
+            "0-Acetylation (Protein N-term)-(42.01);9-Oxidation (M)-(15.99)".
+
+        Returns
+        -------
+        tuple of (str or None, str or None, set of str)
+            ``(mods, mod_sites, unknown)``. If every modification resolves, ``mods``
+            and ``mod_sites`` are the ``;``-joined strings and ``unknown`` is empty.
+            If any is unresolved, ``mods`` and ``mod_sites`` are ``None`` (the
+            precursor is dropped) and ``unknown`` holds the unresolved names.
+
+        """
+        if not mod_str:
+            return "", "", set()
+
+        mods = []
+        sites = []
+        unknown: Set[str] = set()
+        for raw_entry in mod_str.split(";"):
+            entry = raw_entry.strip()
+            if not entry:
+                continue
+            match = _MOD_ENTRY_PATTERN.match(entry)
+            if match is None:
+                raise ValueError(
+                    f"Invalid PEAKS modification entry '{entry}': expected "
+                    f"'<position><Name>-(<mass>)' (e.g. '9-Oxidation (M)-(15.99)')."
+                )
+            position, name, mass_str = match.groups()
+            mass = float(mass_str)
+
+            if ModificationKeys.N_TERM in name:
+                site = "0"
+                aa_or_term = ModificationKeys.ANY_N_TERM
+            elif ModificationKeys.C_TERM in name:
+                site = "-1"
+                aa_or_term = ModificationKeys.ANY_C_TERM
+            else:
+                site = str(int(position) + 1)  # 0-based -> 1-based
+                aa_or_term = sequence[int(position)]
+
+            mod = self._match_mod_by_mass(mass, aa_or_term)
+            if mod is None:
+                unknown.add(f"{name} ({mass_str}) @ {aa_or_term}")
+            else:
+                mods.append(mod)
+                sites.append(site)
+
+        if unknown:
+            return None, None, unknown
+
+        return (
+            ModificationKeys.SEPARATOR.join(mods),
+            ModificationKeys.SEPARATOR.join(sites),
+            unknown,
         )
-        if matches:
-            best_match = mod_name
-            best_mass_diff = mass_diff
 
-    return best_match
+    def _match_mod_by_mass(self, mass: float, aa_or_term: str) -> Optional[str]:
+        """Resolve one modification to an alphabase name by mass and residue/terminus.
+
+        Parameters
+        ----------
+        mass : float
+            Mass shift from the PEAKS entry (e.g. 15.99).
+        aa_or_term : str
+            The amino acid at the site, or ``Any_N-term`` / ``Any_C-term``.
+
+        Returns
+        -------
+        str or None
+            The matched alphabase mod name (e.g. 'Oxidation@M'), or ``None`` if no
+            candidate in ``mass_mapped_mods`` matches within tolerance.
+
+        """
+        is_terminal = aa_or_term in (
+            ModificationKeys.ANY_N_TERM,
+            ModificationKeys.ANY_C_TERM,
+        )
+        term_suffix = (
+            ModificationKeys.N_TERM
+            if aa_or_term == ModificationKeys.ANY_N_TERM
+            else ModificationKeys.C_TERM
+        )
+
+        best_match = None
+        best_mass_diff = float("inf")
+        for mod_name in self._mass_mapped_mods:
+            if mod_name not in MOD_MASS:
+                continue
+            mass_diff = abs(mass - MOD_MASS[mod_name])
+            if mass_diff >= self._mod_mass_tol or mass_diff >= best_mass_diff:
+                continue
+
+            mod_site = mod_name.split(ModificationKeys.SITE_SEPARATOR)[1]
+            matches = (
+                mod_site.endswith(term_suffix)
+                if is_terminal
+                else mod_site == aa_or_term
+            )
+            if matches:
+                best_match = mod_name
+                best_mass_diff = mass_diff
+
+        return best_match
 
 
 class PeaksLibraryReader(LibraryReaderBase):
@@ -166,7 +278,6 @@ class PeaksLibraryReader(LibraryReaderBase):
         precursor_mz_min: float = 400,
         precursor_mz_max: float = 2000,
         decoy: Optional[str] = None,
-        **kwargs,
     ):
         """Create a PEAKS library reader.
 
@@ -189,11 +300,12 @@ class PeaksLibraryReader(LibraryReaderBase):
             precursor_mz_min=precursor_mz_min,
             precursor_mz_max=precursor_mz_max,
             decoy=decoy,
-            **kwargs,
         )
         reader_config = psm_reader_yaml[self._reader_type]
-        self._mass_mapped_mods = reader_config["mass_mapped_mods"]
-        self._mod_mass_tol = reader_config.get("mod_mass_tol", 0.1)
+        self._mod_translator = PeaksModificationTranslator(
+            reader_config["mass_mapped_mods"],
+            reader_config.get("mod_mass_tol", 0.1),
+        )
 
     def _load_file(self, filename: str) -> pd.DataFrame:
         """Load the wide PEAKS export and explode it into long (per-fragment) format."""
@@ -203,27 +315,59 @@ class PeaksLibraryReader(LibraryReaderBase):
         return self._explode_peaks_list(wide_df)
 
     def _explode_peaks_list(self, wide_df: pd.DataFrame) -> pd.DataFrame:
-        """Explode the packed ``Peaks List`` column into one row per fragment."""
-        sequences = wide_df[_PEAKS_SEQUENCE_COLUMN].to_numpy()
-        charges = wide_df["z"].to_numpy()
-        precursor_mzs = wide_df["m/z"].to_numpy()
-        rts = wide_df["rt (seconds)"].to_numpy()
-        modifications = wide_df[_PEAKS_MOD_COLUMN].to_numpy()
-        peaks_lists = wide_df[_PEAKS_PEAKS_COLUMN].to_numpy()
+        """Explode the packed ``Peaks List`` column into one row per fragment.
+
+        Source and synthesized column names both come from the yaml ``column_mapping``.
+        Fragment tokens that cannot be parsed are skipped and reported in a warning.
+
+        Parameters
+        ----------
+        wide_df : pd.DataFrame
+            The raw PEAKS export, one row per precursor.
+
+        Returns
+        -------
+        pd.DataFrame
+            Long-format dataframe with one row per fragment, ready for the standard
+            column translation and library pipeline.
+
+        """
+        cm = self.column_mapping
+        seq_col = cm[PsmDfCols.SEQUENCE]
+        charge_col = cm[PsmDfCols.CHARGE]
+        precursor_mz_col = cm[PsmDfCols.PRECURSOR_MZ]
+        rt_col = cm[PsmDfCols.RT]
+        mod_col = cm[PsmDfCols.TMP_MODS]  # raw 'Modifications' column, parsed later
+        peaks_col = cm["peaks_list"]
+
+        frag_mz_col = cm[LibPsmDfCols.FRAGMENT_MZ]
+        frag_intensity_col = cm[LibPsmDfCols.FRAGMENT_INTENSITY]
+        frag_type_col = cm[LibPsmDfCols.FRAGMENT_TYPE]
+        frag_charge_col = cm[LibPsmDfCols.FRAGMENT_CHARGE]
+        frag_number_col = cm[LibPsmDfCols.FRAGMENT_SERIES]
+        frag_loss_col = cm[LibPsmDfCols.FRAGMENT_LOSS_TYPE]
 
         records = []
+        skipped_tokens = []
         for sequence, charge, precursor_mz, rt, mod_str, peaks_list in zip(
-            sequences, charges, precursor_mzs, rts, modifications, peaks_lists
+            wide_df[seq_col].to_numpy(),
+            wide_df[charge_col].to_numpy(),
+            wide_df[precursor_mz_col].to_numpy(),
+            wide_df[rt_col].to_numpy(),
+            wide_df[mod_col].to_numpy(),
+            wide_df[peaks_col].to_numpy(),
         ):
             if not peaks_list:
                 continue
             for peak in peaks_list.split(";"):
                 fields = peak.split(":")
                 if len(fields) != 3:  # noqa: PLR2004 mz:intensity:annotation
+                    skipped_tokens.append(peak)
                     continue
                 mz_str, intensity_str, annotation = fields
                 parsed = _parse_fragment_annotation(annotation)
                 if parsed is None:
+                    skipped_tokens.append(annotation)
                     continue
                 frag_type, frag_number, frag_charge, loss_type = parsed
                 records.append(
@@ -242,120 +386,44 @@ class PeaksLibraryReader(LibraryReaderBase):
                     )
                 )
 
+        if skipped_tokens:
+            examples = sorted(set(skipped_tokens))[:5]
+            warnings.warn(
+                f"Skipped {len(skipped_tokens)} PEAKS fragment token(s) with an "
+                f"unrecognized annotation; these peaks are not imported. "
+                f"Examples: {examples}"
+            )
+
         return pd.DataFrame(
             records,
             columns=[
-                _PEAKS_SEQUENCE_COLUMN,
-                "z",
-                "m/z",
-                "rt (seconds)",
-                _PEAKS_MOD_COLUMN,
-                _FRAGMENT_MZ,
-                _FRAGMENT_INTENSITY,
-                _FRAGMENT_TYPE,
-                _FRAGMENT_CHARGE,
-                _FRAGMENT_NUMBER,
-                _FRAGMENT_LOSS_TYPE,
+                seq_col,
+                charge_col,
+                precursor_mz_col,
+                rt_col,
+                mod_col,
+                frag_mz_col,
+                frag_intensity_col,
+                frag_type_col,
+                frag_charge_col,
+                frag_number_col,
+                frag_loss_col,
             ],
         )
 
-    def _load_modifications(self, origin_df: pd.DataFrame) -> None:
-        """Parse the PEAKS ``Modifications`` column into ``mods``/``mod_sites``.
+    def _load_modifications(self, origin_df: pd.DataFrame) -> None:  # noqa: ARG002
+        """Parse the raw PEAKS ``Modifications`` column into ``mods``/``mod_sites`` columns.
 
-        Precursors whose modifications are not in ``mass_mapped_mods`` are dropped
-        and reported together in a single warning.
+        The raw column is mapped to ``_tmp_mods`` via the yaml ``column_mapping``
+        and then translated to alphabase mods and mod_sites via :class:`PeaksModificationTranslator`.
         """
-        cache = {}
-        unknown_mods: Set[str] = set()
-        mods_list = []
-        sites_list = []
-        for sequence, mod_str in zip(
-            origin_df[_PEAKS_SEQUENCE_COLUMN].to_numpy(),
-            origin_df[_PEAKS_MOD_COLUMN].to_numpy(),
-        ):
-            key = (sequence, mod_str)
-            if key not in cache:
-                cache[key] = self._parse_peaks_modifications(sequence, mod_str)
-            mods, sites, unknown = cache[key]
-            unknown_mods.update(unknown)
-            # NaN mods flag the precursor for removal by the inherited _post_process
-            mods_list.append(mods if mods is not None else np.nan)
-            sites_list.append(sites if sites is not None else np.nan)
-
-        self._psm_df[PsmDfCols.MODS] = mods_list
-        self._psm_df[PsmDfCols.MOD_SITES] = sites_list
-
-        if unknown_mods:
-            warnings.warn(
-                f"Unknown PEAKS modifications: {sorted(unknown_mods)}. Precursors "
-                f"with these modifications will be removed. Add them to "
-                f"'mass_mapped_mods' for 'peaks_library' in psm_reader.yaml to keep them."
+        self._psm_df[PsmDfCols.MODS], self._psm_df[PsmDfCols.MOD_SITES] = (
+            self._mod_translator.translate(
+                self._psm_df[PsmDfCols.SEQUENCE].to_numpy(),
+                self._psm_df[PsmDfCols.TMP_MODS].to_numpy(),
             )
-
-    def _parse_peaks_modifications(
-        self, sequence: str, mod_str: str
-    ) -> Tuple[Optional[str], Optional[str], Set[str]]:
-        """Parse a single PEAKS ``Modifications`` cell.
-
-        Positions are 0-based indices into the backbone sequence; a mod whose name
-        contains 'N-term'/'C-term' is terminal regardless of position.
-
-        Returns
-        -------
-        tuple
-            ``(mods, mod_sites, unknown)``. If every modification resolves, ``mods``
-            and ``mod_sites`` are the ``;``-joined strings and ``unknown`` is empty.
-            If any modification is unresolved, ``mods``/``mod_sites`` are ``None``
-            (signalling the precursor should be dropped) and ``unknown`` holds the
-            unresolved names for aggregated warning.
-
-        """
-        if not mod_str:
-            return "", "", set()
-
-        mods = []
-        sites = []
-        unknown: Set[str] = set()
-        for raw_entry in mod_str.split(";"):
-            entry = raw_entry.strip()
-            if not entry:
-                continue
-            match = _MOD_ENTRY_PATTERN.match(entry)
-            if match is None:
-                raise ValueError(
-                    f"Invalid PEAKS modification entry '{entry}': expected "
-                    f"'<position><Name>-(<mass>)' (e.g. '9-Oxidation (M)-(15.99)')."
-                )
-            position, name, mass_str = match.groups()
-            mass = float(mass_str)
-
-            if "N-term" in name:
-                site = "0"
-                aa_or_term = ModificationKeys.ANY_N_TERM
-            elif "C-term" in name:
-                site = "-1"
-                aa_or_term = ModificationKeys.ANY_C_TERM
-            else:
-                site = str(int(position) + 1)  # 0-based -> 1-based
-                aa_or_term = sequence[int(position)]
-
-            mod = _match_mod_by_mass(
-                mass, aa_or_term, self._mass_mapped_mods, self._mod_mass_tol
-            )
-            if mod is None:
-                unknown.add(f"{name} ({mass_str}) @ {aa_or_term}")
-            else:
-                mods.append(mod)
-                sites.append(site)
-
-        if unknown:
-            return None, None, unknown
-
-        return (
-            ModificationKeys.SEPARATOR.join(mods),
-            ModificationKeys.SEPARATOR.join(sites),
-            unknown,
         )
+        self._psm_df.drop(columns=[PsmDfCols.TMP_MODS], inplace=True)
 
     def _translate_modifications(self) -> None:
         """No-op: modifications are already resolved in :meth:`_load_modifications`."""

--- a/alphabase/spectral_library/peaks_reader.py
+++ b/alphabase/spectral_library/peaks_reader.py
@@ -1,0 +1,361 @@
+"""Reader for PEAKS Studio DIA spectral library exports.
+
+PEAKS stores one row per precursor with all fragment peaks packed into a single
+``Peaks List`` column; :class:`PeaksLibraryReader` reads this into a standard
+alphabase spectral library.
+"""
+
+import re
+import warnings
+from typing import List, Optional, Set, Tuple
+
+import numpy as np
+import pandas as pd
+
+from alphabase.constants.modification import MOD_MASS, ModificationKeys
+from alphabase.psm_reader.keys import PsmDfCols
+from alphabase.psm_reader.psm_reader import psm_reader_yaml
+from alphabase.spectral_library.reader import LibraryReaderBase
+
+# Column names in the raw PEAKS export.
+_PEAKS_SEQUENCE_COLUMN = "Sequence (backbone)"
+_PEAKS_MOD_COLUMN = "Modifications"
+_PEAKS_PEAKS_COLUMN = "Peaks List"
+
+# Internal (synthesized) long-format fragment column names, mapped in psm_reader.yaml.
+_FRAGMENT_MZ = "FragmentMz"
+_FRAGMENT_INTENSITY = "FragmentIntensity"
+_FRAGMENT_TYPE = "FragmentType"
+_FRAGMENT_CHARGE = "FragmentCharge"
+_FRAGMENT_NUMBER = "FragmentNumber"
+_FRAGMENT_LOSS_TYPE = "FragmentLossType"
+
+# A fragment annotation, e.g. 'b6', 'y13[2+]', 'b12-H2O', 'y5-NH3[3+]'.
+_FRAGMENT_ANNOTATION_PATTERN = re.compile(
+    r"^([abcxyz])(\d+)(?:-(H2O|NH3))?(?:\[(\d+)\+\])?$"
+)
+
+# A modification entry, e.g. '9-Oxidation (M)-(15.99)', '0-Acetylation (Protein N-term)-(42.01)'.
+_MOD_ENTRY_PATTERN = re.compile(r"^(\d+)-(.+)-\(([0-9.]+)\)$")
+
+# The fragment types present in PEAKS DIA libraries: b/y ions up to charge 3 with
+# H2O and NH3 neutral losses. Used as the default so none of the file's peaks are
+# silently dropped (the LibraryReaderBase default omits H2O/NH3 losses).
+DEFAULT_PEAKS_CHARGED_FRAG_TYPES = [
+    "b_z1",
+    "b_z2",
+    "b_z3",
+    "y_z1",
+    "y_z2",
+    "y_z3",
+    "b_H2O_z1",
+    "b_H2O_z2",
+    "b_H2O_z3",
+    "y_H2O_z1",
+    "y_H2O_z2",
+    "y_H2O_z3",
+    "b_NH3_z1",
+    "b_NH3_z2",
+    "b_NH3_z3",
+    "y_NH3_z1",
+    "y_NH3_z2",
+    "y_NH3_z3",
+]
+
+
+def _parse_fragment_annotation(
+    annotation: str,
+) -> Optional[Tuple[str, int, int, str]]:
+    """Parse a PEAKS fragment annotation into its components.
+
+    Parameters
+    ----------
+    annotation : str
+        Fragment annotation like 'b6', 'y13[2+]', 'b12-H2O', 'y5-NH3[3+]'.
+
+    Returns
+    -------
+    tuple or None
+        (fragment_type, fragment_number, fragment_charge, loss_type), e.g.
+        ('y', 13, 2, ''). Returns None if the annotation cannot be parsed.
+
+    """
+    match = _FRAGMENT_ANNOTATION_PATTERN.match(annotation)
+    if match is None:
+        return None
+    frag_type, number, loss, charge = match.groups()
+    return frag_type, int(number), int(charge) if charge else 1, loss or ""
+
+
+def _match_mod_by_mass(
+    mass: float,
+    aa_or_term: str,
+    mass_mapped_mods: List[str],
+    mod_mass_tol: float,
+) -> Optional[str]:
+    """Resolve a PEAKS modification to an alphabase name by mass and residue/terminus.
+
+    Parameters
+    ----------
+    mass : float
+        Mass shift from the PEAKS entry (e.g. 15.99).
+    aa_or_term : str
+        The amino acid at the modification site, or ``Any_N-term`` / ``Any_C-term``.
+    mass_mapped_mods : List[str]
+        Candidate alphabase mod names (e.g. ['Oxidation@M', 'Carboxymethyl@C']).
+    mod_mass_tol : float
+        Mass tolerance in Daltons.
+
+    Returns
+    -------
+    str or None
+        The matched alphabase modification name (e.g. 'Oxidation@M'), or ``None``
+        if no candidate matches the mass and residue/terminus within tolerance.
+
+    """
+    is_terminal = aa_or_term in (
+        ModificationKeys.ANY_N_TERM,
+        ModificationKeys.ANY_C_TERM,
+    )
+    term_keyword = "N-term" if aa_or_term == ModificationKeys.ANY_N_TERM else "C-term"
+
+    best_match = None
+    best_mass_diff = float("inf")
+    for mod_name in mass_mapped_mods:
+        if mod_name not in MOD_MASS:
+            continue
+        mass_diff = abs(mass - MOD_MASS[mod_name])
+        if mass_diff >= mod_mass_tol or mass_diff >= best_mass_diff:
+            continue
+
+        mod_site = mod_name.split(ModificationKeys.SITE_SEPARATOR)[1]
+        matches = (
+            mod_site.endswith(term_keyword) if is_terminal else mod_site == aa_or_term
+        )
+        if matches:
+            best_match = mod_name
+            best_mass_diff = mass_diff
+
+    return best_match
+
+
+class PeaksLibraryReader(LibraryReaderBase):
+    """Read a PEAKS Studio DIA spectral library into an alphabase spectral library.
+
+    Examples
+    --------
+    >>> reader = PeaksLibraryReader()
+    >>> reader.import_file("peak_dia_db_library.tsv")
+    >>> reader.precursor_df           # precursors: sequence, mods, charge, rt, ...
+    >>> reader.fragment_intensity_df  # per-fragment intensities
+    >>> reader.fragment_mz_df         # per-fragment m/z
+
+    """
+
+    _reader_type = "peaks_library"
+
+    def __init__(  # noqa: PLR0913 many arguments
+        self,
+        charged_frag_types: Optional[List[str]] = None,
+        column_mapping: Optional[dict] = None,
+        modification_mapping: Optional[dict] = None,
+        fdr: float = 0.01,
+        fixed_C57: bool = False,  # noqa: N803, FBT001, FBT002
+        mod_seq_columns: Optional[List[str]] = None,
+        rt_unit: Optional[str] = None,
+        precursor_mz_min: float = 400,
+        precursor_mz_max: float = 2000,
+        decoy: Optional[str] = None,
+        **kwargs,
+    ):
+        """Create a PEAKS library reader.
+
+        Parameters are those of :class:`LibraryReaderBase`. By default
+        ``charged_frag_types`` covers b/y ions up to charge 3 with H2O and NH3
+        neutral losses, matching the fragment types PEAKS reports.
+        """
+        super().__init__(
+            charged_frag_types=(
+                DEFAULT_PEAKS_CHARGED_FRAG_TYPES
+                if charged_frag_types is None
+                else charged_frag_types
+            ),
+            column_mapping=column_mapping,
+            modification_mapping=modification_mapping,
+            fdr=fdr,
+            fixed_C57=fixed_C57,
+            mod_seq_columns=mod_seq_columns,
+            rt_unit=rt_unit,
+            precursor_mz_min=precursor_mz_min,
+            precursor_mz_max=precursor_mz_max,
+            decoy=decoy,
+            **kwargs,
+        )
+        reader_config = psm_reader_yaml[self._reader_type]
+        self._mass_mapped_mods = reader_config["mass_mapped_mods"]
+        self._mod_mass_tol = reader_config.get("mod_mass_tol", 0.1)
+
+    def _load_file(self, filename: str) -> pd.DataFrame:
+        """Load the wide PEAKS export and explode it into long (per-fragment) format."""
+        # Explicit tab separator: the 'Activation Mode' value contains a comma
+        # (e.g. "CID, CAD(y and b ions)") which would fool delimiter sniffing.
+        wide_df = pd.read_csv(filename, sep="\t", keep_default_na=False)
+        return self._explode_peaks_list(wide_df)
+
+    def _explode_peaks_list(self, wide_df: pd.DataFrame) -> pd.DataFrame:
+        """Explode the packed ``Peaks List`` column into one row per fragment."""
+        sequences = wide_df[_PEAKS_SEQUENCE_COLUMN].to_numpy()
+        charges = wide_df["z"].to_numpy()
+        precursor_mzs = wide_df["m/z"].to_numpy()
+        rts = wide_df["rt (seconds)"].to_numpy()
+        modifications = wide_df[_PEAKS_MOD_COLUMN].to_numpy()
+        peaks_lists = wide_df[_PEAKS_PEAKS_COLUMN].to_numpy()
+
+        records = []
+        for sequence, charge, precursor_mz, rt, mod_str, peaks_list in zip(
+            sequences, charges, precursor_mzs, rts, modifications, peaks_lists
+        ):
+            if not peaks_list:
+                continue
+            for peak in peaks_list.split(";"):
+                fields = peak.split(":")
+                if len(fields) != 3:  # noqa: PLR2004 mz:intensity:annotation
+                    continue
+                mz_str, intensity_str, annotation = fields
+                parsed = _parse_fragment_annotation(annotation)
+                if parsed is None:
+                    continue
+                frag_type, frag_number, frag_charge, loss_type = parsed
+                records.append(
+                    (
+                        sequence,
+                        charge,
+                        precursor_mz,
+                        rt,
+                        mod_str,
+                        float(mz_str),
+                        float(intensity_str),
+                        frag_type,
+                        frag_charge,
+                        frag_number,
+                        loss_type,
+                    )
+                )
+
+        return pd.DataFrame(
+            records,
+            columns=[
+                _PEAKS_SEQUENCE_COLUMN,
+                "z",
+                "m/z",
+                "rt (seconds)",
+                _PEAKS_MOD_COLUMN,
+                _FRAGMENT_MZ,
+                _FRAGMENT_INTENSITY,
+                _FRAGMENT_TYPE,
+                _FRAGMENT_CHARGE,
+                _FRAGMENT_NUMBER,
+                _FRAGMENT_LOSS_TYPE,
+            ],
+        )
+
+    def _load_modifications(self, origin_df: pd.DataFrame) -> None:
+        """Parse the PEAKS ``Modifications`` column into ``mods``/``mod_sites``.
+
+        Precursors whose modifications are not in ``mass_mapped_mods`` are dropped
+        and reported together in a single warning.
+        """
+        cache = {}
+        unknown_mods: Set[str] = set()
+        mods_list = []
+        sites_list = []
+        for sequence, mod_str in zip(
+            origin_df[_PEAKS_SEQUENCE_COLUMN].to_numpy(),
+            origin_df[_PEAKS_MOD_COLUMN].to_numpy(),
+        ):
+            key = (sequence, mod_str)
+            if key not in cache:
+                cache[key] = self._parse_peaks_modifications(sequence, mod_str)
+            mods, sites, unknown = cache[key]
+            unknown_mods.update(unknown)
+            # NaN mods flag the precursor for removal by the inherited _post_process
+            mods_list.append(mods if mods is not None else np.nan)
+            sites_list.append(sites if sites is not None else np.nan)
+
+        self._psm_df[PsmDfCols.MODS] = mods_list
+        self._psm_df[PsmDfCols.MOD_SITES] = sites_list
+
+        if unknown_mods:
+            warnings.warn(
+                f"Unknown PEAKS modifications: {sorted(unknown_mods)}. Precursors "
+                f"with these modifications will be removed. Add them to "
+                f"'mass_mapped_mods' for 'peaks_library' in psm_reader.yaml to keep them."
+            )
+
+    def _parse_peaks_modifications(
+        self, sequence: str, mod_str: str
+    ) -> Tuple[Optional[str], Optional[str], Set[str]]:
+        """Parse a single PEAKS ``Modifications`` cell.
+
+        Positions are 0-based indices into the backbone sequence; a mod whose name
+        contains 'N-term'/'C-term' is terminal regardless of position.
+
+        Returns
+        -------
+        tuple
+            ``(mods, mod_sites, unknown)``. If every modification resolves, ``mods``
+            and ``mod_sites`` are the ``;``-joined strings and ``unknown`` is empty.
+            If any modification is unresolved, ``mods``/``mod_sites`` are ``None``
+            (signalling the precursor should be dropped) and ``unknown`` holds the
+            unresolved names for aggregated warning.
+
+        """
+        if not mod_str:
+            return "", "", set()
+
+        mods = []
+        sites = []
+        unknown: Set[str] = set()
+        for raw_entry in mod_str.split(";"):
+            entry = raw_entry.strip()
+            if not entry:
+                continue
+            match = _MOD_ENTRY_PATTERN.match(entry)
+            if match is None:
+                raise ValueError(
+                    f"Invalid PEAKS modification entry '{entry}': expected "
+                    f"'<position><Name>-(<mass>)' (e.g. '9-Oxidation (M)-(15.99)')."
+                )
+            position, name, mass_str = match.groups()
+            mass = float(mass_str)
+
+            if "N-term" in name:
+                site = "0"
+                aa_or_term = ModificationKeys.ANY_N_TERM
+            elif "C-term" in name:
+                site = "-1"
+                aa_or_term = ModificationKeys.ANY_C_TERM
+            else:
+                site = str(int(position) + 1)  # 0-based -> 1-based
+                aa_or_term = sequence[int(position)]
+
+            mod = _match_mod_by_mass(
+                mass, aa_or_term, self._mass_mapped_mods, self._mod_mass_tol
+            )
+            if mod is None:
+                unknown.add(f"{name} ({mass_str}) @ {aa_or_term}")
+            else:
+                mods.append(mod)
+                sites.append(site)
+
+        if unknown:
+            return None, None, unknown
+
+        return (
+            ModificationKeys.SEPARATOR.join(mods),
+            ModificationKeys.SEPARATOR.join(sites),
+            unknown,
+        )
+
+    def _translate_modifications(self) -> None:
+        """No-op: modifications are already resolved in :meth:`_load_modifications`."""

--- a/alphabase/spectral_library/peaks_reader.py
+++ b/alphabase/spectral_library/peaks_reader.py
@@ -25,6 +25,10 @@ _FRAGMENT_ANNOTATION_PATTERN = re.compile(
 # A modification entry, e.g. '9-Oxidation (M)-(15.99)', '0-Acetylation (Protein N-term)-(42.01)'.
 _MOD_ENTRY_PATTERN = re.compile(r"^(\d+)-(.+)-\(([0-9.]+)\)$")
 
+# Markers PEAKS writes inside a terminal modification name, e.g. "Acetylation (Protein N-term)"
+_PEAKS_N_TERM_MARKER = "N-term"
+_PEAKS_C_TERM_MARKER = "C-term"
+
 # The fragment types present in PEAKS DIA libraries: b/y ions up to charge 3 with
 # H2O and NH3 neutral losses. Used as the default so none of the file's peaks are
 # silently dropped (the LibraryReaderBase default omits H2O/NH3 losses).
@@ -176,10 +180,10 @@ class PeaksModificationTranslator:
             position, name, mass_str = match.groups()
             mass = float(mass_str)
 
-            if ModificationKeys.N_TERM in name:
+            if _PEAKS_N_TERM_MARKER in name:
                 site = "0"
                 aa_or_term = ModificationKeys.ANY_N_TERM
-            elif ModificationKeys.C_TERM in name:
+            elif _PEAKS_C_TERM_MARKER in name:
                 site = "-1"
                 aa_or_term = ModificationKeys.ANY_C_TERM
             else:
@@ -335,20 +339,22 @@ class PeaksLibraryReader(LibraryReaderBase):
             column translation and library pipeline.
 
         """
-        cm = self.column_mapping
-        seq_col = cm[PsmDfCols.SEQUENCE]
-        charge_col = cm[PsmDfCols.CHARGE]
-        precursor_mz_col = cm[PsmDfCols.PRECURSOR_MZ]
-        rt_col = cm[PsmDfCols.RT]
-        mod_col = cm[PsmDfCols.TMP_MODS]  # raw 'Modifications' column, parsed later
+        column_mapping = self.column_mapping
+        seq_col = column_mapping[PsmDfCols.SEQUENCE]
+        charge_col = column_mapping[PsmDfCols.CHARGE]
+        precursor_mz_col = column_mapping[PsmDfCols.PRECURSOR_MZ]
+        rt_col = column_mapping[PsmDfCols.RT]
+        mod_col = column_mapping[
+            PsmDfCols.TMP_MODS
+        ]  # raw 'Modifications' column, parsed later
         peaks_col = self._peaks_list_column
 
-        frag_mz_col = cm[LibPsmDfCols.FRAGMENT_MZ]
-        frag_intensity_col = cm[LibPsmDfCols.FRAGMENT_INTENSITY]
-        frag_type_col = cm[LibPsmDfCols.FRAGMENT_TYPE]
-        frag_charge_col = cm[LibPsmDfCols.FRAGMENT_CHARGE]
-        frag_number_col = cm[LibPsmDfCols.FRAGMENT_SERIES]
-        frag_loss_col = cm[LibPsmDfCols.FRAGMENT_LOSS_TYPE]
+        frag_mz_col = column_mapping[LibPsmDfCols.FRAGMENT_MZ]
+        frag_intensity_col = column_mapping[LibPsmDfCols.FRAGMENT_INTENSITY]
+        frag_type_col = column_mapping[LibPsmDfCols.FRAGMENT_TYPE]
+        frag_charge_col = column_mapping[LibPsmDfCols.FRAGMENT_CHARGE]
+        frag_number_col = column_mapping[LibPsmDfCols.FRAGMENT_SERIES]
+        frag_loss_col = column_mapping[LibPsmDfCols.FRAGMENT_LOSS_TYPE]
 
         records = []
         skipped_tokens = []

--- a/alphabase/spectral_library/peaks_reader.py
+++ b/alphabase/spectral_library/peaks_reader.py
@@ -306,6 +306,8 @@ class PeaksLibraryReader(LibraryReaderBase):
             reader_config["mass_mapped_mods"],
             reader_config.get("mod_mass_tol", 0.1),
         )
+        # raw fragment column read directly
+        self._peaks_list_column = reader_config["peaks_list_column"]
 
     def _load_file(self, filename: str) -> pd.DataFrame:
         """Load the wide PEAKS export and explode it into long (per-fragment) format."""
@@ -317,7 +319,8 @@ class PeaksLibraryReader(LibraryReaderBase):
     def _explode_peaks_list(self, wide_df: pd.DataFrame) -> pd.DataFrame:
         """Explode the packed ``Peaks List`` column into one row per fragment.
 
-        Source and synthesized column names both come from the yaml ``column_mapping``.
+        Precursor and synthesized fragment column names come from the yaml
+        ``column_mapping``; the packed source column comes from ``peaks_list_column``.
         Fragment tokens that cannot be parsed are skipped and reported in a warning.
 
         Parameters
@@ -338,7 +341,7 @@ class PeaksLibraryReader(LibraryReaderBase):
         precursor_mz_col = cm[PsmDfCols.PRECURSOR_MZ]
         rt_col = cm[PsmDfCols.RT]
         mod_col = cm[PsmDfCols.TMP_MODS]  # raw 'Modifications' column, parsed later
-        peaks_col = cm["peaks_list"]
+        peaks_col = self._peaks_list_column
 
         frag_mz_col = cm[LibPsmDfCols.FRAGMENT_MZ]
         frag_intensity_col = cm[LibPsmDfCols.FRAGMENT_INTENSITY]

--- a/docs/modules_spectral_library.rst
+++ b/docs/modules_spectral_library.rst
@@ -8,4 +8,5 @@ alphabase.spectral_library
    spectral_library/flat
    spectral_library/decoy
    spectral_library/reader
+   spectral_library/peaks_reader
    spectral_library/translate

--- a/docs/spectral_library/peaks_reader.rst
+++ b/docs/spectral_library/peaks_reader.rst
@@ -1,0 +1,9 @@
+alphabase.spectral_library.peaks_reader
+=======================================
+
+Reader for PEAKS Studio DIA spectral library exports.
+
+.. automodule:: alphabase.spectral_library.peaks_reader
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/tests/unit/psm_reader/test_peaks_library_reader.py
+++ b/tests/unit/psm_reader/test_peaks_library_reader.py
@@ -1,0 +1,241 @@
+"""Unit tests for the PEAKS DIA spectral library reader.
+
+Every test builds its input inline from a few hand-written PEAKS rows and writes
+it to a pytest ``tmp_path`` file. Nothing here reads the real example library, so
+there is no committed data-file dependency.
+"""
+
+import numpy as np
+import pytest
+
+from alphabase.psm_reader.keys import PsmDfCols
+from alphabase.spectral_library.peaks_reader import (
+    DEFAULT_PEAKS_CHARGED_FRAG_TYPES,
+    PeaksLibraryReader,
+    _match_mod_by_mass,
+    _parse_fragment_annotation,
+)
+
+# The 9 columns of a PEAKS DIA library export. The reader only consumes
+# 'Sequence (backbone)', 'z', 'm/z', 'rt (seconds)', 'Modifications' and
+# 'Peaks List'; the other three are filler to keep the shape realistic.
+_COLUMNS = [
+    "m/z",
+    "z",
+    "rt (seconds)",
+    "Activation Mode",
+    "Sequence (backbone)",
+    "Modifications",
+    "Peaks Count",
+    "Peaks List",
+    "Engine",
+]
+
+
+def _row(sequence, mods, peaks, *, charge="2", mz="500.0", rt="83.0"):
+    """Build one PEAKS library row as a list of cell strings.
+
+    Parameters
+    ----------
+    sequence : str
+        Backbone sequence, e.g. "PEPTIDEK".
+    mods : str
+        The PEAKS 'Modifications' cell, ';'-separated '<pos>-<name>-(<mass>)'
+        entries (empty string for an unmodified precursor).
+    peaks : str
+        The 'Peaks List' cell: ';'-separated 'mz:intensity:annotation' triplets,
+        e.g. "200.1:50:b2;350.1:100:y3".
+
+    """
+    peak_count = str(len(peaks.split(";"))) if peaks else "0"
+    return [
+        mz,
+        charge,
+        rt,
+        "CID, CAD(y and b ions)",
+        sequence,
+        mods,
+        peak_count,
+        peaks,
+        "DB_SEARCH",
+    ]
+
+
+def _write_library(tmp_path, rows):
+    """Write a PEAKS-format TSV (header + rows) to tmp_path, return its path."""
+    lines = ["\t".join(_COLUMNS)] + ["\t".join(row) for row in rows]
+    path = tmp_path / "sample_peaks_library.tsv"
+    path.write_text("\n".join(lines))
+    return str(path)
+
+
+@pytest.fixture
+def sample_library(tmp_path):
+    """A 3-precursor sample covering the features the reader must handle.
+
+    - PEPTIDEK: no mods; fragments include an H2O loss, an NH3 loss and a 2+ ion.
+    - AMPEPTK:  N-terminal acetylation + a positional Met oxidation.
+    - ACPEPTK:  a positional Carboxymethyl on Cys.
+    """
+    return _write_library(
+        tmp_path,
+        [
+            _row(
+                "PEPTIDEK",
+                "",
+                "200.1:50:b2;400.2:30:b4-H2O;350.1:100:y3;500.2:40:y5[2+];250.1:20:y2-NH3",
+                mz="456.7",
+                rt="83.0",
+            ),
+            _row(
+                "AMPEPTK",
+                "0-Acetylation (Protein N-term)-(42.01);1-Oxidation (M)-(15.99)",
+                "100.1:100:b1;250.1:80:y2;300.2:50:y4[2+]",
+                mz="400.2",
+                rt="90.0",
+            ),
+            _row(
+                "ACPEPTK",
+                "1-Carboxymethyl-(58.01)",
+                "180.1:100:b2;320.1:60:y3",
+                mz="410.2",
+                rt="95.0",
+            ),
+        ],
+    )
+
+
+class TestFragmentAnnotationParsing:
+    """Tests for _parse_fragment_annotation (annotation string -> components)."""
+
+    @pytest.mark.parametrize(
+        ("annotation", "expected"),
+        [
+            ("b6", ("b", 6, 1, "")),
+            ("y13[2+]", ("y", 13, 2, "")),
+            ("b12-H2O", ("b", 12, 1, "H2O")),
+            ("y5-NH3", ("y", 5, 1, "NH3")),
+            ("y5-NH3[3+]", ("y", 5, 3, "NH3")),
+        ],
+    )
+    def test_valid_annotations(self, annotation, expected):
+        assert _parse_fragment_annotation(annotation) == expected
+
+    @pytest.mark.parametrize("annotation", ["", "garbage", "b", "z+"])
+    def test_invalid_annotations(self, annotation):
+        assert _parse_fragment_annotation(annotation) is None
+
+
+class TestModificationMatching:
+    """Tests for _match_mod_by_mass (mass + residue -> alphabase mod name)."""
+
+    _CANDIDATES = ["Carboxymethyl@C", "Oxidation@M", "Acetyl@Protein_N-term"]
+
+    def test_positional_match_uses_residue(self):
+        assert _match_mod_by_mass(15.99, "M", self._CANDIDATES, 0.1) == "Oxidation@M"
+        assert (
+            _match_mod_by_mass(58.01, "C", self._CANDIDATES, 0.1) == "Carboxymethyl@C"
+        )
+
+    def test_terminal_match(self):
+        assert (
+            _match_mod_by_mass(42.01, "Any_N-term", self._CANDIDATES, 0.1)
+            == "Acetyl@Protein_N-term"
+        )
+
+    def test_unknown_mass_returns_none(self):
+        assert _match_mod_by_mass(79.97, "S", self._CANDIDATES, 0.1) is None
+
+    def test_wrong_residue_returns_none(self):
+        # 58.01 exists as Carboxymethyl@C but not on residue 'A'
+        assert _match_mod_by_mass(58.01, "A", self._CANDIDATES, 0.1) is None
+
+
+class TestReaderBasics:
+    """Tests for reader construction and configuration."""
+
+    def test_initialization(self):
+        reader = PeaksLibraryReader()
+        assert reader._reader_type == "peaks_library"
+        assert reader.charged_frag_types == DEFAULT_PEAKS_CHARGED_FRAG_TYPES
+        assert "Oxidation@M" in reader._mass_mapped_mods
+        assert reader._mod_mass_tol == 0.1
+        assert reader.column_mapping[PsmDfCols.SEQUENCE] == "Sequence (backbone)"
+
+
+class TestEndToEnd:
+    """Tests for the full import pipeline on a written sample library."""
+
+    def test_modifications_are_parsed(self, sample_library):
+        reader = PeaksLibraryReader()
+        reader.import_file(sample_library)
+
+        precursor_df = reader.precursor_df.set_index("sequence")
+        assert len(precursor_df) == 3
+
+        # unmodified precursor -> empty mods/sites
+        assert precursor_df.loc["PEPTIDEK", "mods"] == ""
+        assert precursor_df.loc["PEPTIDEK", "mod_sites"] == ""
+
+        # N-terminal acetyl (site 0) + Met oxidation (PEAKS 0-based pos 1 -> site 2)
+        assert (
+            precursor_df.loc["AMPEPTK", "mods"] == "Acetyl@Protein_N-term;Oxidation@M"
+        )
+        assert precursor_df.loc["AMPEPTK", "mod_sites"] == "0;2"
+
+        # Carboxymethyl on Cys (PEAKS 0-based pos 1 -> site 2)
+        assert precursor_df.loc["ACPEPTK", "mods"] == "Carboxymethyl@C"
+        assert precursor_df.loc["ACPEPTK", "mod_sites"] == "2"
+
+    def test_fragment_tables(self, sample_library):
+        reader = PeaksLibraryReader()
+        reader.import_file(sample_library)
+
+        # one dense fragment row per (nAA - 1) per precursor: 7 + 6 + 6 = 19
+        expected_rows = sum(reader.precursor_df["nAA"] - 1)
+        assert expected_rows == 19
+        assert len(reader.fragment_intensity_df) == expected_rows
+        assert reader.fragment_intensity_df.shape == reader.fragment_mz_df.shape
+        assert (
+            list(reader.fragment_intensity_df.columns)
+            == DEFAULT_PEAKS_CHARGED_FRAG_TYPES
+        )
+
+        # every precursor's intensities are normalized to a max of 1.0
+        intensities = reader.fragment_intensity_df.to_numpy()
+        for start, stop in zip(
+            reader.precursor_df["frag_start_idx"],
+            reader.precursor_df["frag_stop_idx"],
+        ):
+            assert np.isclose(intensities[start:stop].max(), 1.0)
+
+    def test_neutral_loss_and_charge_fragments_are_kept(self, sample_library):
+        reader = PeaksLibraryReader()
+        reader.import_file(sample_library)
+
+        peptidek = reader.precursor_df.set_index("sequence").loc["PEPTIDEK"]
+        frags = reader.fragment_intensity_df.iloc[
+            peptidek["frag_start_idx"] : peptidek["frag_stop_idx"]
+        ]
+        # H2O loss, NH3 loss and a 2+ fragment all survived the import
+        assert frags["b_H2O_z1"].sum() > 0
+        assert frags["y_NH3_z1"].sum() > 0
+        assert frags["y_z2"].sum() > 0
+
+    def test_unmapped_modification_warns_and_drops_precursor(self, tmp_path):
+        """An unresolved modification drops its precursor (and warns), keeping the rest."""
+        library = _write_library(
+            tmp_path,
+            [
+                _row("PEPTIDEK", "", "200.1:50:b2;350.1:100:y3"),
+                # Phospho is not in mass_mapped_mods -> unresolved -> dropped
+                _row("SPEPTIK", "0-Phospho-(79.97)", "180.1:60:b2;300.1:100:y3"),
+            ],
+        )
+
+        reader = PeaksLibraryReader()
+        with pytest.warns(UserWarning, match="Unknown PEAKS modifications"):
+            reader.import_file(library)
+
+        sequences = set(reader.precursor_df["sequence"])
+        assert sequences == {"PEPTIDEK"}  # good precursor survives, bad one dropped

--- a/tests/unit/psm_reader/test_peaks_library_reader.py
+++ b/tests/unit/psm_reader/test_peaks_library_reader.py
@@ -6,13 +6,14 @@ there is no committed data-file dependency.
 """
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from alphabase.psm_reader.keys import PsmDfCols
 from alphabase.spectral_library.peaks_reader import (
     DEFAULT_PEAKS_CHARGED_FRAG_TYPES,
     PeaksLibraryReader,
-    _match_mod_by_mass,
+    PeaksModificationTranslator,
     _parse_fragment_annotation,
 )
 
@@ -127,28 +128,30 @@ class TestFragmentAnnotationParsing:
 
 
 class TestModificationMatching:
-    """Tests for _match_mod_by_mass (mass + residue -> alphabase mod name)."""
+    """Tests for PeaksModificationTranslator._match_mod_by_mass (mass + residue -> name)."""
 
     _CANDIDATES = ["Carboxymethyl@C", "Oxidation@M", "Acetyl@Protein_N-term"]
 
-    def test_positional_match_uses_residue(self):
-        assert _match_mod_by_mass(15.99, "M", self._CANDIDATES, 0.1) == "Oxidation@M"
-        assert (
-            _match_mod_by_mass(58.01, "C", self._CANDIDATES, 0.1) == "Carboxymethyl@C"
-        )
+    @pytest.fixture
+    def translator(self):
+        return PeaksModificationTranslator(self._CANDIDATES, mod_mass_tol=0.1)
 
-    def test_terminal_match(self):
+    def test_positional_match_uses_residue(self, translator):
+        assert translator._match_mod_by_mass(15.99, "M") == "Oxidation@M"
+        assert translator._match_mod_by_mass(58.01, "C") == "Carboxymethyl@C"
+
+    def test_terminal_match(self, translator):
         assert (
-            _match_mod_by_mass(42.01, "Any_N-term", self._CANDIDATES, 0.1)
+            translator._match_mod_by_mass(42.01, "Any_N-term")
             == "Acetyl@Protein_N-term"
         )
 
-    def test_unknown_mass_returns_none(self):
-        assert _match_mod_by_mass(79.97, "S", self._CANDIDATES, 0.1) is None
+    def test_unknown_mass_returns_none(self, translator):
+        assert translator._match_mod_by_mass(79.97, "S") is None
 
-    def test_wrong_residue_returns_none(self):
+    def test_wrong_residue_returns_none(self, translator):
         # 58.01 exists as Carboxymethyl@C but not on residue 'A'
-        assert _match_mod_by_mass(58.01, "A", self._CANDIDATES, 0.1) is None
+        assert translator._match_mod_by_mass(58.01, "A") is None
 
 
 class TestReaderBasics:
@@ -158,8 +161,8 @@ class TestReaderBasics:
         reader = PeaksLibraryReader()
         assert reader._reader_type == "peaks_library"
         assert reader.charged_frag_types == DEFAULT_PEAKS_CHARGED_FRAG_TYPES
-        assert "Oxidation@M" in reader._mass_mapped_mods
-        assert reader._mod_mass_tol == 0.1
+        assert "Oxidation@M" in reader._mod_translator._mass_mapped_mods
+        assert reader._mod_translator._mod_mass_tol == 0.1
         assert reader.column_mapping[PsmDfCols.SEQUENCE] == "Sequence (backbone)"
 
 
@@ -170,22 +173,24 @@ class TestEndToEnd:
         reader = PeaksLibraryReader()
         reader.import_file(sample_library)
 
-        precursor_df = reader.precursor_df.set_index("sequence")
-        assert len(precursor_df) == 3
-
-        # unmodified precursor -> empty mods/sites
-        assert precursor_df.loc["PEPTIDEK", "mods"] == ""
-        assert precursor_df.loc["PEPTIDEK", "mod_sites"] == ""
-
-        # N-terminal acetyl (site 0) + Met oxidation (PEAKS 0-based pos 1 -> site 2)
-        assert (
-            precursor_df.loc["AMPEPTK", "mods"] == "Acetyl@Protein_N-term;Oxidation@M"
+        # sequence/mods/mod_sites/charge for every precursor, in one comparison.
+        # - PEPTIDEK: unmodified -> empty mods/sites
+        # - AMPEPTK:  N-terminal acetyl (site 0) + Met oxidation (0-based pos 1 -> site 2)
+        # - ACPEPTK:  Carboxymethyl on Cys (0-based pos 1 -> site 2)
+        expected = pd.DataFrame(
+            {
+                "sequence": ["ACPEPTK", "AMPEPTK", "PEPTIDEK"],
+                "mods": ["Carboxymethyl@C", "Acetyl@Protein_N-term;Oxidation@M", ""],
+                "mod_sites": ["2", "0;2", ""],
+                "charge": np.array(
+                    [2, 2, 2], dtype=reader.precursor_df["charge"].dtype
+                ),
+            }
         )
-        assert precursor_df.loc["AMPEPTK", "mod_sites"] == "0;2"
-
-        # Carboxymethyl on Cys (PEAKS 0-based pos 1 -> site 2)
-        assert precursor_df.loc["ACPEPTK", "mods"] == "Carboxymethyl@C"
-        assert precursor_df.loc["ACPEPTK", "mod_sites"] == "2"
+        actual = reader.precursor_df.sort_values("sequence").reset_index(drop=True)[
+            expected.columns
+        ]
+        pd.testing.assert_frame_equal(actual, expected)
 
     def test_fragment_tables(self, sample_library):
         reader = PeaksLibraryReader()


### PR DESCRIPTION
<!--
  Briefly describe the changes your PR makes.
  Include any info that might be relevant for reviewers to understand the context.
-->


## Add PeaksLibraryReader for PEAKS Studio DIA spectral libraries

Imports a PEAKS Studio DIA spectral library export (`dia_db_library.tsv`) into a
standard AlphaBase spectral library (`precursor_df` + `fragment_intensity_df` +
`fragment_mz_df`).

- Unpacks the PEAKS wide format (fragments packed in one `Peaks List` cell) into
  the long format `LibraryReaderBase` already consumes — no core changes.
- Parses b/y fragment annotations up to charge 3 with H2O/NH3 losses.
- Resolves the `Modifications` column by mass + the residue read from the sequence;
  unmapped mods warn and drop the precursor instead of aborting.

```python
# Example use case
reader = PeaksLibraryReader()
reader.import_file("peak_dia_db_library.tsv")
```
---

#### To-do list (outside contributers only)
- [ ] I have read and agree to the [MannLabs Contributor License Agreement](https://github.com/MannLabs/.github/blob/main/CLA.md)