### PR TITLE
fix: encode heavy isotopes in TMT6/10plex SMILES annotations

### DIFF
--- a/alphabase/constants/const_files/modification.tsv
+++ b/alphabase/constants/const_files/modification.tsv
@@ -1027,19 +1027,19 @@ Ethanolamine@D	43.042199	43.0678	H(5)C(2)N(1)	0.0		Chemical derivative	734		0.0
 Ethanolamine@Any_C-term	43.042199	43.0678	H(5)C(2)N(1)	0.0		Chemical derivative	734		0.0
 Ethanolamine@E	43.042199	43.0678	H(5)C(2)N(1)	0.0		Chemical derivative	734		0.0
 Ethanolamine@C	43.042199	43.0678	H(5)C(2)N(1)	0.0		Chemical derivative	734		0.0
-TMT6plex@T	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737	CC1N(CC(NCCC(=O)O[C@H](C)[C@@H](N([Fl])([Fl]))C(=O)[Ts])=O)C(C)CCC1	0.0
-TMT6plex@S	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737	CC1N(CC(NCCC(=O)OC[C@@H](N([Fl])([Fl]))C(=O)[Ts])=O)C(C)CCC1	0.0
+TMT6plex@T	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737	[13CH3][13CH]1[15N](CC(NCCC(=O)O[C@H](C)[C@@H](N([Fl])([Fl]))C(=O)[Ts])=O)[13CH]([13CH3])CCC1	0.0
+TMT6plex@S	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737	[13CH3][13CH]1[15N](CC(NCCC(=O)OC[C@@H](N([Fl])([Fl]))C(=O)[Ts])=O)[13CH]([13CH3])CCC1	0.0
 TMT6plex@H	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737		0.0
-TMT6plex@Protein_N-term	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737	CC1N(CC(NCCC(=O)[Lv])=O)C(C)CCC1	0.0
-TMT6plex@Any_N-term	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737	CC1N(CC(NCCC(=O)[Lv])=O)C(C)CCC1	0.0
-TMT6plex@K	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737	CC1N(CC(NCCC(=O)NCCCC[C@H](N([Fl])([Fl]))C(=O)[Ts])=O)C(C)CCC1	0.0
-TMT6plex@Y	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737	CC1N(CC(NCCC(=O)Oc2ccc(C[C@@H](C(=O)[Ts])N([Fl])([Fl]))cc2)=O)C(C)CCC1	0.0
+TMT6plex@Protein_N-term	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737	[13CH3][13CH]1[15N](CC(NCCC(=O)[Lv])=O)[13CH]([13CH3])CCC1	0.0
+TMT6plex@Any_N-term	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737	[13CH3][13CH]1[15N](CC(NCCC(=O)[Lv])=O)[13CH]([13CH3])CCC1	0.0
+TMT6plex@K	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737	[13CH3][13CH]1[15N](CC(NCCC(=O)NCCCC[C@H](N([Fl])([Fl]))C(=O)[Ts])=O)[13CH]([13CH3])CCC1	0.0
+TMT6plex@Y	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737	[13CH3][13CH]1[15N](CC(NCCC(=O)Oc2ccc(C[C@@H](C(=O)[Ts])N([Fl])([Fl]))cc2)=O)[13CH]([13CH3])CCC1	0.0
 TMT10plex@T	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737		0.0
 TMT10plex@S	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737		0.0
 TMT10plex@H	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737		0.0
 TMT10plex@Protein_N-term	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737		0.0
-TMT10plex@Any_N-term	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737	C(=O)CCNC(=O)CN1C(C)CCCC1C	0.0
-TMT10plex@K	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737	CC1N(CC(NCCC(NCCCC[C@H](N([Fl])([Fl]))C(=O)[Ts])=O)=O)C(C)CCC1	0.0
+TMT10plex@Any_N-term	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737	[13CH3][13CH]1[15N](CC(NCCC(=O)[Lv])=O)[13CH]([13CH3])CCC1	0.0
+TMT10plex@K	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737	[13CH3][13CH]1[15N](CC(NCCC(=O)NCCCC[C@H](N([Fl])([Fl]))C(=O)[Ts])=O)[13CH]([13CH3])CCC1	0.0
 TMT10plex@Y	229.162932	229.2634	H(20)C(8)13C(4)N(1)15N(1)O(2)	0.0		Isotopic label	737		0.0
 BEMAD_C@C	120.0245	120.1701	H(8)C(4)O(2)S(1)	0.0		Chemical derivative	736		0.0
 TMT2plex@H	225.155833	225.2921	H(20)C(11)13C(1)N(2)O(2)	0.0		Isotopic label	738		0.0

--- a/alphabase/constants/const_files/modification.tsv
+++ b/alphabase/constants/const_files/modification.tsv
@@ -2714,8 +2714,8 @@ TMTpro@T	304.207146	304.3127	H(25)C(8)13C(7)N(1)15N(2)O(3)	0.0		Isotopic label	2
 TMTpro@S	304.207146	304.3127	H(25)C(8)13C(7)N(1)15N(2)O(3)	0.0		Isotopic label	2016		0.0
 TMTpro@H	304.207146	304.3127	H(25)C(8)13C(7)N(1)15N(2)O(3)	0.0		Isotopic label	2016		0.0
 TMTpro@Protein_N-term	304.207146	304.3127	H(25)C(8)13C(7)N(1)15N(2)O(3)	0.0		Isotopic label	2016		0.0
-TMTpro@Any_N-term	304.207146	304.3127	H(25)C(8)13C(7)N(1)15N(2)O(3)	0.0		Isotopic label	2016	C(=O)CCCNC(=O)CCCNC(=O)C1N(CC(C)C)CCC1	0.0
-TMTpro@K	304.207146	304.3127	H(25)C(8)13C(7)N(1)15N(2)O(3)	0.0		Isotopic label	2016	CC(CN1C(C(NCCC(NCCC(NCCCC[C@H](N([Fl])([Fl]))C(=O)[Ts])=O)=O)=O)CCC1)C	0.0
+TMTpro@Any_N-term	304.207146	304.3127	H(25)C(8)13C(7)N(1)15N(2)O(3)	0.0		Isotopic label	2016	CC(C)CN1CCCC1[13C](=O)[15NH][13CH2][13CH2][13C](=O)[15NH][13CH2][13CH2][13C](=O)[Lv]	0.0
+TMTpro@K	304.207146	304.3127	H(25)C(8)13C(7)N(1)15N(2)O(3)	0.0		Isotopic label	2016	CC(C)CN1CCCC1[13C](=O)[15NH][13CH2][13CH2][13C](=O)[15NH][13CH2][13CH2][13C](=O)NCCCC[C@@H]([C](=O)[Ts])[N]([Fl])[Fl]	0.0
 TMTpro_zero@S	295.189592	295.3773	H(25)C(15)N(3)O(3)	0.0		Chemical derivative	2017		0.0
 TMTpro_zero@H	295.189592	295.3773	H(25)C(15)N(3)O(3)	0.0		Chemical derivative	2017		0.0
 TMTpro_zero@Protein_N-term	295.189592	295.3773	H(25)C(15)N(3)O(3)	0.0		Chemical derivative	2017		0.0


### PR DESCRIPTION
The smiles column for TMT6plex/TMT10plex encoded the light tag (all 12C/14N), disagreeing with the declared composition H(20)C(8)13C(4)N(1)15N(1)O(2) by ~5 Da. Add [13CH]/[13CH3]/[15N] labels to the dimethylpiperidine reporter so the SMILES matches the composition, and unify the malformed TMT10plex@Any_N-term skeleton with its TMT6plex twin. Verified each mod delta reproduces the declared composition exactly (H included).

<!--
  Briefly describe the changes your PR makes.
  Include any info that might be relevant for reviewers to understand the context.
-->



---

#### To-do list (outside contributers only)
- [x] I have read and agree to the [MannLabs Contributor License Agreement](https://github.com/MannLabs/.github/blob/main/CLA.md)