### PR TITLE
Share the modification registry with multiprocessing workers

### DIFF
--- a/alphabase/constants/modification.py
+++ b/alphabase/constants/modification.py
@@ -1,3 +1,11 @@
+"""Modification registry.
+
+`MOD_DF` is the single source of truth: every other module-level lookup here is
+derived from it and rebuilt in place by :func:`update_all_by_MOD_DF`. Anything
+that mutates the registry must go through that function, which is what makes
+:func:`get_modification_state` a complete snapshot of the registry.
+"""
+
 import os
 from typing import List, Union
 
@@ -463,7 +471,7 @@ def _check_mass_sanity(
     composition_mass = calc_mass_from_formula(composition)
     if not np.allclose(composition_mass, MOD_MASS[mod_name], atol=1e-5):
         raise ValueError(
-            f"Modification mass of {mod_name} is inconsistent with the composition formula: {composition}, df version {MOD_DF.loc[mod_name,['composition']]}"
+            f"Modification mass of {mod_name} is inconsistent with the composition formula: {composition}, df version {MOD_DF.loc[mod_name, ['composition']]}"
             f" calculated_mass={composition_mass}, mod_mass={MOD_MASS[mod_name]}"
         )
 
@@ -531,6 +539,36 @@ def _add_a_new_modification(
 def has_custom_mods():
     """Returns whether `MOD_DF` has user-defined modifications or not."""
     return len(MOD_DF[MOD_DF["classification"] == _MOD_CLASSIFICATION_USER_ADDED]) > 0
+
+
+def get_modification_state() -> pd.DataFrame:
+    """Snapshot the modification registry so it can be handed to another process.
+
+    Returns
+    -------
+    pd.DataFrame
+        A copy of :data:`MOD_DF`. It carries every runtime change to the
+        registry, not just user-added modifications.
+    """
+    return MOD_DF.copy()
+
+
+def set_modification_state(mod_df: pd.DataFrame) -> None:
+    """Install a registry snapshot and rebuild every derived lookup.
+
+    Processes started with the "spawn" start method re-import alphabase and so
+    see only the modifications in `modification.tsv`. Without this, every
+    runtime change -- custom modifications, modloss filtering, lower-case AAs,
+    a custom TSV -- is silently absent in workers.
+
+    Parameters
+    ----------
+    mod_df : pd.DataFrame
+        Snapshot as returned by :func:`get_modification_state`.
+    """
+    global MOD_DF
+    MOD_DF = mod_df
+    update_all_by_MOD_DF()
 
 
 def add_new_modifications(new_mods: Union[list, dict]):

--- a/alphabase/constants/modification.py
+++ b/alphabase/constants/modification.py
@@ -1,9 +1,8 @@
 """Modification registry.
 
-`MOD_DF` is the single source of truth: every other module-level lookup here is
-derived from it and rebuilt in place by :func:`update_all_by_MOD_DF`. Anything
-that mutates the registry must go through that function, which is what makes
-:func:`get_modification_state` a complete snapshot of the registry.
+`update_all_by_MOD_DF` calculates all other module-level lookups from `MOD_DF`.
+Thus a copy of `MOD_DF` is a complete snapshot of the registry. Change the
+registry only with `update_all_by_MOD_DF`, to keep this true.
 """
 
 import os
@@ -542,29 +541,28 @@ def has_custom_mods():
 
 
 def get_modification_state() -> pd.DataFrame:
-    """Snapshot the modification registry so it can be handed to another process.
+    """Copy the modification registry, to send it to a different process.
 
     Returns
     -------
     pd.DataFrame
-        A copy of :data:`MOD_DF`. It carries every runtime change to the
-        registry, not just user-added modifications.
+        A copy of :data:`MOD_DF`. It contains all changes made at run time, not
+        only the user-added modifications.
     """
     return MOD_DF.copy()
 
 
 def set_modification_state(mod_df: pd.DataFrame) -> None:
-    """Install a registry snapshot and rebuild every derived lookup.
+    """Install a registry copy and calculate the derived lookups again.
 
-    Processes started with the "spawn" start method re-import alphabase and so
-    see only the modifications in `modification.tsv`. Without this, every
-    runtime change -- custom modifications, modloss filtering, lower-case AAs,
-    a custom TSV -- is silently absent in workers.
+    A process that starts with the "spawn" method imports alphabase again. Thus
+    it knows only the modifications in `modification.tsv`. Use this function to
+    give the process all changes that were made at run time.
 
     Parameters
     ----------
     mod_df : pd.DataFrame
-        Snapshot as returned by :func:`get_modification_state`.
+        A copy from :func:`get_modification_state`.
     """
     global MOD_DF
     MOD_DF = mod_df

--- a/alphabase/peptide/precursor.py
+++ b/alphabase/peptide/precursor.py
@@ -1,4 +1,3 @@
-import multiprocessing as mp
 import typing
 from functools import partial
 
@@ -13,6 +12,7 @@ from alphabase.constants.isotope import IsotopeDistribution
 from alphabase.constants.modification import MOD_Composition, ModificationKeys
 from alphabase.numba_wrapper import numba_njit
 from alphabase.peptide.mass_calc import calc_peptide_masses_for_same_len_seqs
+from alphabase.utils import spawn_pool
 
 
 def refine_precursor_df(
@@ -537,7 +537,7 @@ def calc_precursor_isotope_info_mp(
         )
     df_list = []
     df_group = precursor_df.groupby("nAA")
-    with mp.get_context("spawn").Pool(processes) as p:
+    with spawn_pool(processes) as p:
         processing = p.imap(
             partial(
                 calc_precursor_isotope_info,
@@ -681,7 +681,7 @@ def calc_precursor_isotope_intensity_mp(
     df_list = []
     df_group = precursor_df.groupby("nAA")
 
-    with mp.get_context("spawn").Pool(mp_process_num) as p:
+    with spawn_pool(mp_process_num) as p:
         processing = p.imap(
             partial(
                 calc_precursor_isotope_intensity,

--- a/alphabase/peptide/precursor.py
+++ b/alphabase/peptide/precursor.py
@@ -3,7 +3,6 @@ from functools import partial
 
 import numpy as np
 import pandas as pd
-from tqdm import tqdm
 from xxhash import xxh64_intdigest
 
 from alphabase.constants.aa import AA_Composition
@@ -12,7 +11,7 @@ from alphabase.constants.isotope import IsotopeDistribution
 from alphabase.constants.modification import MOD_Composition, ModificationKeys
 from alphabase.numba_wrapper import numba_njit
 from alphabase.peptide.mass_calc import calc_peptide_masses_for_same_len_seqs
-from alphabase.utils import spawn_pool
+from alphabase.utils import parallel_apply
 
 
 def refine_precursor_df(
@@ -475,24 +474,6 @@ def calc_precursor_isotope_info(
     return precursor_df
 
 
-def _batchify_df(df_group, mp_batch_size):
-    """Internal funciton for multiprocessing"""
-    for _, df in df_group:
-        for i in range(0, len(df), mp_batch_size):
-            yield df.iloc[i : i + mp_batch_size, :]
-
-
-def _count_batchify_df(df_group, mp_batch_size):
-    """Internal funciton for multiprocessing"""
-    count = 0
-    for _, df in df_group:
-        for _ in range(0, len(df), mp_batch_size):
-            count += 1
-    return count
-
-
-# `progress_bar` should be replaced by more advanced tqdm wrappers created by Sander
-# I will leave it to alphabase.utils
 def calc_precursor_isotope_info_mp(
     precursor_df: pd.DataFrame,
     processes: int = 8,
@@ -535,23 +516,17 @@ def calc_precursor_isotope_info_mp(
             precursor_df=precursor_df,
             min_right_most_intensity=min_right_most_intensity,
         )
-    df_list = []
-    df_group = precursor_df.groupby("nAA")
-    with spawn_pool(processes) as p:
-        processing = p.imap(
-            partial(
-                calc_precursor_isotope_info,
-                min_right_most_intensity=min_right_most_intensity,
-            ),
-            _batchify_df(df_group, mp_batch_size),
-        )
-        if progress_bar:
-            processing = progress_bar(
-                processing, _count_batchify_df(df_group, mp_batch_size)
-            )
-        for df in processing:
-            df_list.append(df)
-    return pd.concat(df_list)
+    return parallel_apply(
+        partial(
+            calc_precursor_isotope_info,
+            min_right_most_intensity=min_right_most_intensity,
+        ),
+        precursor_df,
+        processes=processes,
+        batch_size=mp_batch_size,
+        group_by="nAA",
+        progress=progress_bar,
+    )
 
 
 def calc_precursor_isotope_intensity(
@@ -678,28 +653,20 @@ def calc_precursor_isotope_intensity_mp(
             normalize=normalize,
         )
 
-    df_list = []
-    df_group = precursor_df.groupby("nAA")
-
-    with spawn_pool(mp_process_num) as p:
-        processing = p.imap(
-            partial(
-                calc_precursor_isotope_intensity,
-                max_isotope=max_isotope,
-                min_right_most_intensity=min_right_most_intensity,
-                normalize=normalize,
-            ),
-            _batchify_df(df_group, mp_batch_size),
-        )
-
-        if progress_bar:
-            df_list = list(
-                tqdm(processing, total=_count_batchify_df(df_group, mp_batch_size))
-            )
-        else:
-            df_list = list(processing)
-
-    return pd.concat(df_list, ignore_index=True)
+    return parallel_apply(
+        partial(
+            calc_precursor_isotope_intensity,
+            max_isotope=max_isotope,
+            min_right_most_intensity=min_right_most_intensity,
+            normalize=normalize,
+        ),
+        precursor_df,
+        processes=mp_process_num,
+        batch_size=mp_batch_size,
+        group_by="nAA",
+        progress=progress_bar,
+        ignore_index=True,
+    )
 
 
 calc_precursor_isotope = calc_precursor_isotope_intensity

--- a/alphabase/psm_reader/sage_reader.py
+++ b/alphabase/psm_reader/sage_reader.py
@@ -4,11 +4,10 @@ import logging
 import re
 from abc import ABC
 from functools import partial
-from typing import Generator, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
-from tqdm import tqdm
 
 from alphabase.constants.modification import MOD_DF, ModificationKeys
 from alphabase.psm_reader.keys import PsmDfCols
@@ -16,7 +15,7 @@ from alphabase.psm_reader.psm_reader import (
     PSMReaderBase,
     psm_reader_provider,
 )
-from alphabase.utils import spawn_pool
+from alphabase.utils import parallel_apply
 
 
 class SageModificationTranslator:
@@ -443,27 +442,6 @@ def _apply_translate_modifications(
     return psm_df
 
 
-def _batchify_df(df: pd.DataFrame, mp_batch_size: int) -> Generator:
-    """Internal funciton for applying translation modifications in parallel.
-
-    Parameters
-    ----------
-    df : pd.DataFrame
-        The PSM dataframe.
-
-    mp_batch_size : int
-        The batch size for parallel processing.
-
-    Returns
-    -------
-    typing.Generator
-        A generator for the batchified dataframe.
-
-    """
-    for i in range(0, len(df), mp_batch_size):
-        yield df.iloc[i : i + mp_batch_size, :]
-
-
 def _apply_translate_modifications_mp(
     psm_df: pd.DataFrame,
     mod_translation_df: pd.DataFrame,
@@ -492,22 +470,17 @@ def _apply_translate_modifications_mp(
         Whether to show a progress bar. Defaults to True
 
     """
-    with spawn_pool(mp_process_num) as p:
-        processing = p.imap(
-            partial(
-                _apply_translate_modifications,
-                mod_translation_df=mod_translation_df,
-            ),
-            _batchify_df(psm_df, mp_batch_size),
-        )
-        if progress_bar:
-            df_list = list(
-                tqdm(processing, total=int(np.ceil(len(psm_df) / mp_batch_size)))
-            )
-        else:
-            df_list = list(processing)
-
-    return pd.concat(df_list, ignore_index=True)
+    return parallel_apply(
+        partial(
+            _apply_translate_modifications,
+            mod_translation_df=mod_translation_df,
+        ),
+        psm_df,
+        processes=mp_process_num,
+        batch_size=mp_batch_size,
+        progress=progress_bar,
+        ignore_index=True,
+    )
 
 
 def _get_annotated_mod_df() -> pd.DataFrame:

--- a/alphabase/psm_reader/sage_reader.py
+++ b/alphabase/psm_reader/sage_reader.py
@@ -1,7 +1,6 @@
 """SageReader for reading Sage output files."""
 
 import logging
-import multiprocessing as mp
 import re
 from abc import ABC
 from functools import partial
@@ -17,6 +16,7 @@ from alphabase.psm_reader.psm_reader import (
     PSMReaderBase,
     psm_reader_provider,
 )
+from alphabase.utils import spawn_pool
 
 
 class SageModificationTranslator:
@@ -492,7 +492,7 @@ def _apply_translate_modifications_mp(
         Whether to show a progress bar. Defaults to True
 
     """
-    with mp.get_context("spawn").Pool(mp_process_num) as p:
+    with spawn_pool(mp_process_num) as p:
         processing = p.imap(
             partial(
                 _apply_translate_modifications,

--- a/alphabase/spectral_library/base.py
+++ b/alphabase/spectral_library/base.py
@@ -477,7 +477,8 @@ class SpecLibBase:
             (self._precursor_df) = calc_precursor_isotope_info_mp(
                 self.precursor_df,
                 processes=mp_process_num,
-                process_bar=mp_process_bar,
+                mp_batch_size=mp_batch_size,
+                progress_bar=mp_process_bar,
             )
         else:
             (self._precursor_df) = calc_precursor_isotope_info(self.precursor_df)

--- a/alphabase/spectral_library/base.py
+++ b/alphabase/spectral_library/base.py
@@ -7,7 +7,6 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from alphabase.constants.modification import has_custom_mods
 from alphabase.io.hdf import HDF_File
 from alphabase.peptide.fragment import (
     calc_fragment_count,
@@ -428,13 +427,6 @@ class SpecLibBase:
         do_multiprocessing = (
             mp_process_num > 1 and len(self.precursor_df) > mp_batch_size
         )
-
-        if do_multiprocessing and has_custom_mods():
-            logging.warning(
-                "Multiprocessing not compatible with custom modifications yet, falling back to single process."
-            )
-            do_multiprocessing = False
-            # TODO enable multiprocessing also in this case
 
         if do_multiprocessing:
             (self._precursor_df) = calc_precursor_isotope_intensity_mp(

--- a/alphabase/spectral_library/decoy.py
+++ b/alphabase/spectral_library/decoy.py
@@ -4,13 +4,7 @@ from typing import Any
 import pandas as pd
 
 from alphabase.spectral_library.base import SpecLibBase
-from alphabase.utils import spawn_pool
-
-
-def _batchify_series(series, mp_batch_size):
-    """Internal funciton for multiprocessing"""
-    for i in range(0, len(series), mp_batch_size):
-        yield series.iloc[i : i + mp_batch_size]
+from alphabase.utils import parallel_apply
 
 
 class BaseDecoyGenerator:
@@ -190,16 +184,13 @@ class SpecLibDecoy(SpecLibBase):
             self._remove_target_seqs()
             return
 
-        sequence_batches = list(
-            _batchify_series(self._precursor_df["sequence"], mp_batch_size)
+        self._precursor_df["sequence"] = parallel_apply(
+            self.generator,
+            self._precursor_df["sequence"],
+            processes=mp_process_num,
+            batch_size=mp_batch_size,
+            progress=False,
         )
-
-        series_list = []
-        with spawn_pool(mp_process_num) as p:
-            processing = p.imap(self.generator, sequence_batches)
-            for df in processing:
-                series_list.append(df)
-        self._precursor_df["sequence"] = pd.concat(series_list)
         self._remove_target_seqs()
 
     def _remove_target_seqs(self):

--- a/alphabase/spectral_library/decoy.py
+++ b/alphabase/spectral_library/decoy.py
@@ -1,10 +1,10 @@
 import copy
-import multiprocessing as mp
 from typing import Any
 
 import pandas as pd
 
 from alphabase.spectral_library.base import SpecLibBase
+from alphabase.utils import spawn_pool
 
 
 def _batchify_series(series, mp_batch_size):
@@ -195,7 +195,7 @@ class SpecLibDecoy(SpecLibBase):
         )
 
         series_list = []
-        with mp.get_context("spawn").Pool(mp_process_num) as p:
+        with spawn_pool(mp_process_num) as p:
             processing = p.imap(self.generator, sequence_batches)
             for df in processing:
                 series_list.append(df)

--- a/alphabase/utils.py
+++ b/alphabase/utils.py
@@ -79,12 +79,11 @@ def _get_delimiter(file_path: str) -> str:
 
 
 def _spawn_pool(processes: int, *, context=None):
-    """Create a worker pool that shares this process's modification registry.
+    """Create a worker pool that shares the modification registry.
 
-    Workers are started with the "spawn" start method and re-import alphabase
-    from scratch, so they would otherwise lose every runtime change to the
-    modification registry. The snapshot is taken once here and installed in each
-    worker as it starts.
+    A worker starts with the "spawn" method and imports alphabase again. Thus it
+    loses all changes that were made to the registry at run time. This function
+    copies the registry one time, then installs it in each worker at start.
     """
     ctx = context if context is not None else mp.get_context("spawn")
     return ctx.Pool(
@@ -95,7 +94,7 @@ def _spawn_pool(processes: int, *, context=None):
 
 
 def _batchify(obj, batch_size: int, group_by=None):
-    """Yield row batches of a DataFrame or Series, optionally within groups."""
+    """Divide a DataFrame or Series into batches of rows."""
     groups = (group for _, group in obj.groupby(group_by)) if group_by else iter((obj,))
     for group in groups:
         for i in range(0, len(group), batch_size):
@@ -108,10 +107,11 @@ def _batch_count(obj, batch_size: int, group_by=None) -> int:
 
 
 def _with_progress(iterator, total, progress):
-    """Wrap `iterator` in a progress bar.
+    """Add a progress bar to `iterator`.
 
-    `progress` is True for a tqdm bar, a callable `progress(iterator, total)` to
-    supply your own, or anything falsy for no bar.
+    Set `progress` to True for a tqdm bar. Set it to a callable
+    `progress(iterator, total)` to supply a different bar. Set it to a false
+    value for no bar.
     """
     if progress is True:
         return tqdm.tqdm(iterator, total=total)
@@ -130,28 +130,28 @@ def parallel_imap(
     progress=True,
     context=None,
 ):
-    """Map `func` over `iterable` in workers that share the modification registry.
+    """Apply `func` to each item of `iterable` in workers.
 
-    Results are yielded as they arrive, so callers holding large objects only
-    keep one batch in memory at a time.
+    The workers share the modification registry. This function gives each result
+    when it is ready. Thus the caller keeps only one batch in memory.
 
     Parameters
     ----------
     processes : int
-        Number of worker processes.
+        The number of worker processes.
 
     total : int, optional
-        Number of items, for the progress bar.
+        The number of items, for the progress bar.
 
     unordered : bool, optional
-        Yield results as they finish rather than in input order.
+        Give each result when it is ready, not in the sequence of the input.
 
     progress : bool or callable, optional
         See :func:`_with_progress`.
 
     context : multiprocessing context, optional
-        Substitute context, e.g. `torch.multiprocessing.get_context("spawn")`,
-        whose reducers are needed to share model tensors with workers.
+        A different context, for example `torch.multiprocessing.get_context`.
+        Its reducers are necessary to share model tensors with the workers.
     """
     with _spawn_pool(processes, context=context) as pool:
         mapper = pool.imap_unordered if unordered else pool.imap
@@ -169,17 +169,17 @@ def parallel_apply(
     context=None,
     ignore_index: bool = False,
 ):
-    """Apply `func` to row batches of `obj` in parallel and concatenate the result.
+    """Apply `func` to batches of rows of `obj`, then join the results.
 
     Parameters
     ----------
     obj : pd.DataFrame or pd.Series
-        Object to split into batches.
+        The object to divide into batches.
 
     group_by : optional
-        Column to group by before batching, so each batch is within one group.
+        A column to group by. Each batch then stays in one group.
 
-    See :func:`parallel_imap` for the remaining parameters.
+    See :func:`parallel_imap` for the other parameters.
     """
     return pd.concat(
         list(

--- a/alphabase/utils.py
+++ b/alphabase/utils.py
@@ -1,9 +1,15 @@
 import io
 import itertools
+import multiprocessing as mp
 import warnings
 
 import pandas as pd
 import tqdm
+
+from alphabase.constants.modification import (
+    get_modification_state,
+    set_modification_state,
+)
 
 
 class AlphabaseDeprecationWarning(DeprecationWarning):
@@ -70,3 +76,33 @@ def _get_delimiter(file_path: str) -> str:
         return ","
     else:
         return "\t"
+
+
+def spawn_pool(processes: int, *, context=None, **kwargs):
+    """Create a worker pool that shares this process's modification registry.
+
+    Workers are started with the "spawn" start method and re-import alphabase
+    from scratch, so they would otherwise lose every runtime change to the
+    modification registry. The snapshot is taken once here and installed in each
+    worker as it starts.
+
+    Parameters
+    ----------
+    processes : int
+        Number of worker processes.
+
+    context : multiprocessing context, optional
+        Substitute context, e.g. `torch.multiprocessing.get_context("spawn")`,
+        whose reducers are needed to share model tensors with workers.
+        Defaults to the standard "spawn" context.
+
+    **kwargs
+        Forwarded to `Pool`.
+    """
+    ctx = context if context is not None else mp.get_context("spawn")
+    return ctx.Pool(
+        processes,
+        initializer=set_modification_state,
+        initargs=(get_modification_state(),),
+        **kwargs,
+    )

--- a/alphabase/utils.py
+++ b/alphabase/utils.py
@@ -78,31 +78,119 @@ def _get_delimiter(file_path: str) -> str:
         return "\t"
 
 
-def spawn_pool(processes: int, *, context=None, **kwargs):
+def _spawn_pool(processes: int, *, context=None):
     """Create a worker pool that shares this process's modification registry.
 
     Workers are started with the "spawn" start method and re-import alphabase
     from scratch, so they would otherwise lose every runtime change to the
     modification registry. The snapshot is taken once here and installed in each
     worker as it starts.
-
-    Parameters
-    ----------
-    processes : int
-        Number of worker processes.
-
-    context : multiprocessing context, optional
-        Substitute context, e.g. `torch.multiprocessing.get_context("spawn")`,
-        whose reducers are needed to share model tensors with workers.
-        Defaults to the standard "spawn" context.
-
-    **kwargs
-        Forwarded to `Pool`.
     """
     ctx = context if context is not None else mp.get_context("spawn")
     return ctx.Pool(
         processes,
         initializer=set_modification_state,
         initargs=(get_modification_state(),),
-        **kwargs,
+    )
+
+
+def _batchify(obj, batch_size: int, group_by=None):
+    """Yield row batches of a DataFrame or Series, optionally within groups."""
+    groups = (group for _, group in obj.groupby(group_by)) if group_by else iter((obj,))
+    for group in groups:
+        for i in range(0, len(group), batch_size):
+            yield group.iloc[i : i + batch_size]
+
+
+def _batch_count(obj, batch_size: int, group_by=None) -> int:
+    sizes = obj.groupby(group_by).size().values if group_by else [len(obj)]
+    return sum((size + batch_size - 1) // batch_size for size in sizes)
+
+
+def _with_progress(iterator, total, progress):
+    """Wrap `iterator` in a progress bar.
+
+    `progress` is True for a tqdm bar, a callable `progress(iterator, total)` to
+    supply your own, or anything falsy for no bar.
+    """
+    if progress is True:
+        return tqdm.tqdm(iterator, total=total)
+    if callable(progress):
+        return progress(iterator, total)
+    return iterator
+
+
+def parallel_imap(
+    func,
+    iterable,
+    *,
+    processes: int,
+    total: int = None,
+    unordered: bool = False,
+    progress=True,
+    context=None,
+):
+    """Map `func` over `iterable` in workers that share the modification registry.
+
+    Results are yielded as they arrive, so callers holding large objects only
+    keep one batch in memory at a time.
+
+    Parameters
+    ----------
+    processes : int
+        Number of worker processes.
+
+    total : int, optional
+        Number of items, for the progress bar.
+
+    unordered : bool, optional
+        Yield results as they finish rather than in input order.
+
+    progress : bool or callable, optional
+        See :func:`_with_progress`.
+
+    context : multiprocessing context, optional
+        Substitute context, e.g. `torch.multiprocessing.get_context("spawn")`,
+        whose reducers are needed to share model tensors with workers.
+    """
+    with _spawn_pool(processes, context=context) as pool:
+        mapper = pool.imap_unordered if unordered else pool.imap
+        yield from _with_progress(mapper(func, iterable), total, progress)
+
+
+def parallel_apply(
+    func,
+    obj,
+    *,
+    processes: int,
+    batch_size: int,
+    group_by=None,
+    progress=True,
+    context=None,
+    ignore_index: bool = False,
+):
+    """Apply `func` to row batches of `obj` in parallel and concatenate the result.
+
+    Parameters
+    ----------
+    obj : pd.DataFrame or pd.Series
+        Object to split into batches.
+
+    group_by : optional
+        Column to group by before batching, so each batch is within one group.
+
+    See :func:`parallel_imap` for the remaining parameters.
+    """
+    return pd.concat(
+        list(
+            parallel_imap(
+                func,
+                _batchify(obj, batch_size, group_by),
+                processes=processes,
+                total=_batch_count(obj, batch_size, group_by),
+                progress=progress,
+                context=context,
+            )
+        ),
+        ignore_index=ignore_index,
     )

--- a/tests/unit/peptide/test_precursor_mp.py
+++ b/tests/unit/peptide/test_precursor_mp.py
@@ -1,0 +1,125 @@
+"""Multiprocessing workers must see the same modification registry as the parent.
+
+Workers are started with the "spawn" start method and re-import alphabase, so
+they only see `modification.tsv` unless the registry is handed to them
+explicitly. These tests cover each way the registry can change at runtime.
+"""
+
+import os
+
+import pandas as pd
+import pytest
+
+from alphabase.constants._const import CONST_FILE_FOLDER
+from alphabase.constants.modification import (
+    add_modifications_for_lower_case_AA,
+    add_new_modifications,
+    get_modification_state,
+    keep_modloss_by_importance,
+    load_mod_df,
+    set_modification_state,
+)
+from alphabase.peptide.precursor import (
+    calc_precursor_isotope_intensity,
+    calc_precursor_isotope_intensity_mp,
+    update_precursor_mz,
+)
+from alphabase.utils import spawn_pool
+
+CUSTOM_MOD = "TestCustomMod@K"
+CUSTOM_MOD_COMPOSITION = "H(4)O(2)"
+
+
+@pytest.fixture
+def restore_registry():
+    """Undo the global registry changes each test makes."""
+    snapshot = get_modification_state()
+    yield
+    set_modification_state(snapshot)
+
+
+def _worker_registry(_):
+    """Return the worker process's own view of the registry."""
+    return get_modification_state()
+
+
+def _add_custom_mod():
+    add_new_modifications({CUSTOM_MOD: {"composition": CUSTOM_MOD_COMPOSITION}})
+
+
+def _filter_modloss():
+    # `load_mod_df` applies level 1 at import, keeping 2 modloss values; level 0
+    # keeps 867, so a worker that missed this change is detectably different.
+    keep_modloss_by_importance(0.0)
+
+
+def _add_lower_case_aa():
+    add_modifications_for_lower_case_AA()
+
+
+def _load_custom_tsv():
+    """Load a TSV that differs from the default one shipped with alphabase."""
+    default_tsv = os.path.join(CONST_FILE_FOLDER, "modification.tsv")
+    mod_df = pd.read_table(default_tsv, keep_default_na=False)
+    extra = mod_df.iloc[[0]].copy()
+    extra["mod_name"] = "TestTsvMod@K"
+    extra["composition"] = CUSTOM_MOD_COMPOSITION
+    custom_tsv = os.path.join(
+        os.path.dirname(default_tsv), "_test_modification_tmp.tsv"
+    )
+    pd.concat([mod_df, extra], ignore_index=True).to_csv(
+        custom_tsv, sep="\t", index=False
+    )
+    try:
+        load_mod_df(custom_tsv)
+    finally:
+        os.remove(custom_tsv)
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [_add_custom_mod, _filter_modloss, _add_lower_case_aa, _load_custom_tsv],
+    ids=["custom_mods", "modloss_filtering", "lower_case_AA", "custom_tsv"],
+)
+def test_worker_registry_matches_parent(mutate, restore_registry):
+    # Given a registry changed at runtime
+    mutate()
+    expected = get_modification_state()
+
+    # When a worker process reports its own registry
+    with spawn_pool(2) as pool:
+        registries = pool.map(_worker_registry, [None, None])
+
+    # Then it is identical to the parent's
+    for registry in registries:
+        pd.testing.assert_frame_equal(registry, expected)
+
+
+def _precursor_df(n_precursors=40):
+    df = pd.DataFrame(
+        {
+            "sequence": ["PEPTIDEK"] * n_precursors,
+            "mods": [CUSTOM_MOD] * n_precursors,
+            "mod_sites": ["8"] * n_precursors,
+            "charge": [2] * n_precursors,
+        }
+    )
+    df["nAA"] = df["sequence"].str.len()
+    return update_precursor_mz(df)
+
+
+def test_isotope_intensity_mp_matches_single_process(restore_registry):
+    # Given a library whose precursors carry a custom modification
+    _add_custom_mod()
+    isotope_cols = [f"i_{i}" for i in range(6)]
+
+    # When the isotope intensities are calculated with and without multiprocessing
+    single = calc_precursor_isotope_intensity(_precursor_df(), max_isotope=6)
+    multi = calc_precursor_isotope_intensity_mp(
+        _precursor_df(), max_isotope=6, mp_batch_size=10, mp_process_num=2
+    )
+
+    # Then the results agree
+    pd.testing.assert_frame_equal(
+        single.sort_index()[isotope_cols], multi.sort_index()[isotope_cols]
+    )

--- a/tests/unit/peptide/test_precursor_mp.py
+++ b/tests/unit/peptide/test_precursor_mp.py
@@ -1,8 +1,8 @@
-"""Multiprocessing workers must see the same modification registry as the parent.
+"""A worker must have the same modification registry as the parent process.
 
-Workers are started with the "spawn" start method and re-import alphabase, so
-they only see `modification.tsv` unless the registry is handed to them
-explicitly. These tests cover each way the registry can change at runtime.
+A worker starts with the "spawn" method and imports alphabase again. Thus it
+knows only `modification.tsv`, until the parent sends it the registry. These
+tests examine each change that is possible at run time.
 """
 
 import os
@@ -33,14 +33,14 @@ CUSTOM_MOD_COMPOSITION = "H(4)O(2)"
 
 @pytest.fixture
 def restore_registry():
-    """Undo the global registry changes each test makes."""
+    """Undo the changes that a test makes to the global registry."""
     snapshot = get_modification_state()
     yield
     set_modification_state(snapshot)
 
 
 def _worker_registry(_):
-    """Return the worker process's own view of the registry."""
+    """Give the registry of the worker process."""
     return get_modification_state()
 
 
@@ -49,8 +49,8 @@ def _add_custom_mod():
 
 
 def _filter_modloss():
-    # `load_mod_df` applies level 1 at import, keeping 2 modloss values; level 0
-    # keeps 867, so a worker that missed this change is detectably different.
+    # At import, `load_mod_df` uses level 1 and keeps 2 modloss values. Level 0
+    # keeps 867. Thus a worker without this change is different.
     keep_modloss_by_importance(0.0)
 
 
@@ -59,7 +59,7 @@ def _add_lower_case_aa():
 
 
 def _load_custom_tsv():
-    """Load a TSV that differs from the default one shipped with alphabase."""
+    """Load a TSV that is different from the default TSV of alphabase."""
     default_tsv = os.path.join(CONST_FILE_FOLDER, "modification.tsv")
     mod_df = pd.read_table(default_tsv, keep_default_na=False)
     extra = mod_df.iloc[[0]].copy()
@@ -83,16 +83,16 @@ def _load_custom_tsv():
     ids=["custom_mods", "modloss_filtering", "lower_case_AA", "custom_tsv"],
 )
 def test_worker_registry_matches_parent(mutate, restore_registry):
-    # Given a registry changed at runtime
+    # Given a registry that changed at run time
     mutate()
     expected = get_modification_state()
 
-    # When a worker process reports its own registry
+    # When a worker process gives its own registry
     registries = list(
         parallel_imap(_worker_registry, [None, None], processes=2, progress=False)
     )
 
-    # Then it is identical to the parent's
+    # Then it is the same as the registry of the parent
     for registry in registries:
         pd.testing.assert_frame_equal(registry, expected)
 
@@ -111,31 +111,31 @@ def _precursor_df(n_precursors=40, mod=CUSTOM_MOD):
 
 
 def test_isotope_intensity_mp_matches_single_process(restore_registry):
-    # Given a library whose precursors carry a custom modification
+    # Given a library with a custom modification on its precursors
     _add_custom_mod()
     isotope_cols = [f"i_{i}" for i in range(6)]
 
-    # When the isotope intensities are calculated with and without multiprocessing
+    # When the isotope intensities are calculated with and without workers
     single = calc_precursor_isotope_intensity(_precursor_df(), max_isotope=6)
     multi = calc_precursor_isotope_intensity_mp(
         _precursor_df(), max_isotope=6, mp_batch_size=10, mp_process_num=2
     )
 
-    # Then the results agree
+    # Then the two results are the same
     pd.testing.assert_frame_equal(
         single.sort_index()[isotope_cols], multi.sort_index()[isotope_cols]
     )
 
 
 def test_caller_supplied_progress_bar_is_used():
-    # Given a caller supplying its own progress bar rather than the default
+    # Given a caller that supplies its own progress bar
     seen_totals = []
 
     def progress(iterator, total):
         seen_totals.append(total)
         return iterator
 
-    # When isotope intensities are calculated with multiprocessing
+    # When the isotope intensities are calculated with workers
     calc_precursor_isotope_intensity_mp(
         _precursor_df(40, mod=""),
         max_isotope=6,
@@ -144,17 +144,17 @@ def test_caller_supplied_progress_bar_is_used():
         progress_bar=progress,
     )
 
-    # Then it is actually driven, rather than being treated as a plain flag
+    # Then the code uses the bar, and does not use it as a flag
     assert seen_totals == [4]
 
 
 def test_speclib_isotope_info_runs_with_multiprocessing():
-    # Given a library large enough to take the multiprocessing branch
+    # Given a library that is large enough to use the workers
     lib = SpecLibBase()
     lib._precursor_df = _precursor_df(20_000, mod="")
 
-    # When isotope info is calculated
+    # When the isotope info is calculated
     lib.calc_precursor_isotope_info(mp_process_num=2, mp_batch_size=1000)
 
-    # Then it completes; it used to raise TypeError on an unknown keyword
+    # Then it completes. Before, an unknown keyword caused a TypeError.
     assert "isotope_apex_offset" in lib.precursor_df.columns

--- a/tests/unit/peptide/test_precursor_mp.py
+++ b/tests/unit/peptide/test_precursor_mp.py
@@ -110,6 +110,7 @@ def _precursor_df(n_precursors=40, mod=CUSTOM_MOD):
     return update_precursor_mz(df)
 
 
+@pytest.mark.requires_numba
 def test_isotope_intensity_mp_matches_single_process(restore_registry):
     # Given a library with a custom modification on its precursors
     _add_custom_mod()
@@ -127,6 +128,7 @@ def test_isotope_intensity_mp_matches_single_process(restore_registry):
     )
 
 
+@pytest.mark.requires_numba
 def test_caller_supplied_progress_bar_is_used():
     # Given a caller that supplies its own progress bar
     seen_totals = []
@@ -148,6 +150,7 @@ def test_caller_supplied_progress_bar_is_used():
     assert seen_totals == [4]
 
 
+@pytest.mark.requires_numba
 def test_speclib_isotope_info_runs_with_multiprocessing():
     # Given a library that is large enough to use the workers
     lib = SpecLibBase()

--- a/tests/unit/peptide/test_precursor_mp.py
+++ b/tests/unit/peptide/test_precursor_mp.py
@@ -24,7 +24,8 @@ from alphabase.peptide.precursor import (
     calc_precursor_isotope_intensity_mp,
     update_precursor_mz,
 )
-from alphabase.utils import spawn_pool
+from alphabase.spectral_library.base import SpecLibBase
+from alphabase.utils import parallel_imap
 
 CUSTOM_MOD = "TestCustomMod@K"
 CUSTOM_MOD_COMPOSITION = "H(4)O(2)"
@@ -87,20 +88,21 @@ def test_worker_registry_matches_parent(mutate, restore_registry):
     expected = get_modification_state()
 
     # When a worker process reports its own registry
-    with spawn_pool(2) as pool:
-        registries = pool.map(_worker_registry, [None, None])
+    registries = list(
+        parallel_imap(_worker_registry, [None, None], processes=2, progress=False)
+    )
 
     # Then it is identical to the parent's
     for registry in registries:
         pd.testing.assert_frame_equal(registry, expected)
 
 
-def _precursor_df(n_precursors=40):
+def _precursor_df(n_precursors=40, mod=CUSTOM_MOD):
     df = pd.DataFrame(
         {
             "sequence": ["PEPTIDEK"] * n_precursors,
-            "mods": [CUSTOM_MOD] * n_precursors,
-            "mod_sites": ["8"] * n_precursors,
+            "mods": [mod] * n_precursors,
+            "mod_sites": ["8" if mod else ""] * n_precursors,
             "charge": [2] * n_precursors,
         }
     )
@@ -123,3 +125,36 @@ def test_isotope_intensity_mp_matches_single_process(restore_registry):
     pd.testing.assert_frame_equal(
         single.sort_index()[isotope_cols], multi.sort_index()[isotope_cols]
     )
+
+
+def test_caller_supplied_progress_bar_is_used():
+    # Given a caller supplying its own progress bar rather than the default
+    seen_totals = []
+
+    def progress(iterator, total):
+        seen_totals.append(total)
+        return iterator
+
+    # When isotope intensities are calculated with multiprocessing
+    calc_precursor_isotope_intensity_mp(
+        _precursor_df(40, mod=""),
+        max_isotope=6,
+        mp_batch_size=10,
+        mp_process_num=2,
+        progress_bar=progress,
+    )
+
+    # Then it is actually driven, rather than being treated as a plain flag
+    assert seen_totals == [4]
+
+
+def test_speclib_isotope_info_runs_with_multiprocessing():
+    # Given a library large enough to take the multiprocessing branch
+    lib = SpecLibBase()
+    lib._precursor_df = _precursor_df(20_000, mod="")
+
+    # When isotope info is calculated
+    lib.calc_precursor_isotope_info(mp_process_num=2, mp_batch_size=1000)
+
+    # Then it completes; it used to raise TypeError on an unknown keyword
+    assert "isotope_apex_offset" in lib.precursor_df.columns


### PR DESCRIPTION
## Problem

A worker starts with `spawn` and imports alphabase again. It has only the modifications from `modification.tsv`. Run-time changes are absent: custom modifications, modloss filtering, lower-case AAs, a custom TSV.

`calc_precursor_isotope_intensity` used a fallback to one process. The other multiprocessing functions used the incorrect registry and gave no warning.

## Change

`_spawn_pool()` copies `MOD_DF` in the parent and installs it in each worker, with `get_modification_state()` and `set_modification_state()`. The fallback and `has_custom_mods()` are removed.

The copy is complete, so a new column reaches the workers without a change here. #303 sent selected fields and thus needed a change for each new field.

`parallel_imap()` and `parallel_apply()` in `alphabase/utils.py` are now the only functions that make a pool. Converted: `calc_precursor_isotope_info_mp`, `calc_precursor_isotope_intensity_mp`, `_apply_translate_modifications_mp`, `SpecLibDecoy.translate_to_decoy`. This removes three copies of `_batchify_df` and 125 lines.

Also corrects `calc_precursor_isotope_info`, which sent `process_bar=` to a parameter with the name `progress_bar` and thus raised `TypeError`.

## Tests

`test_worker_registry_matches_parent` compares the registry of the worker with the registry of the parent, after each of four run-time changes. It fails without this PR.
