### PR TITLE
Reduce peak memory of flatten_fragments

### DIFF
--- a/alphabase/peptide/fragment.py
+++ b/alphabase/peptide/fragment.py
@@ -1040,14 +1040,10 @@ def flatten_fragments(
 
     n_fragment_types = len(fragment_mz_df.columns)
 
-    # Only `mz` and `intensity` are required at the full dense length of
-    # n_fragment_rows * n_fragment_types, as they determine which fragments are
-    # retained. Every other flat column is built directly from the indices of the
-    # retained fragments, so neither the dense intermediates for
-    # type/loss_type/charge/number/position nor the copy that filtering an
-    # assembled dataframe would make are ever materialised. Peak memory is thus
-    # driven by the number of retained fragments instead of the number of dense
-    # slots, which for top-k libraries is dominated by mz==0 padding.
+    # Only mz and intensity need the full dense length, because they give the
+    # keep mask. Dense arrays for the other columns and a copy from a filtered
+    # dataframe increase the peak memory. For top-k libraries, mz == 0 padding
+    # fills most dense slots.
     mz = fragment_mz_df.values.reshape(-1)
     use_intensity = len(fragment_intensity_df) > 0
     intensity = (
@@ -1085,7 +1081,7 @@ def flatten_fragments(
     if use_intensity:
         is_padding = mz == 0
         intensity[is_padding] = 0.0
-        # accumulated in place to avoid intermediate dense boolean arrays
+        # in-place operations prevent more dense boolean arrays
         excluded = intensity < min_fragment_intensity
         excluded |= is_padding
         excluded |= excluded_indices
@@ -1094,9 +1090,8 @@ def flatten_fragments(
         excluded = mz == 0
     del excluded_indices
 
-    # `excluded` is inverted in place into the keep mask, which saves another
-    # dense boolean array. The resulting indices are ascending, so indexing with
-    # them retains the fragment order of the dense representation.
+    # The in-place inversion prevents one more dense array. The indices stay
+    # ascending, so the fragments keep their dense order.
     np.logical_not(excluded, out=excluded)
     kept_indices = np.flatnonzero(excluded)
     del excluded
@@ -1105,13 +1100,12 @@ def flatten_fragments(
     frag_df["mz"] = mz[kept_indices]
     if use_intensity:
         frag_df["intensity"] = intensity[kept_indices]
-    # add additional columns to the fragment dataframe
-    # each column in the flat fragment dataframe is a whole pandas dataframe in the dense representation
+    # each custom_df value is a dense dataframe
     for col_name, df in custom_df.items():
         frag_df[col_name] = df.values.reshape(-1)[kept_indices]
 
     if {"type", "loss_type", "charge"} & set(custom_columns):
-        # the charged fragment type of a dense slot is given by its column
+        # the column of a dense slot gives its charged fragment type
         kept_frag_types = kept_indices % n_fragment_types
         if "type" in custom_columns:
             frag_df["type"] = np.array(frag_types, dtype=np.int8)[kept_frag_types]
@@ -1129,9 +1123,8 @@ def flatten_fragments(
     if "position" in custom_columns:
         frag_df["position"] = positions.reshape(-1)[kept_indices]
 
-    # The reannotated pointer of a precursor is the number of retained fragments
-    # before its dense start/stop position. As `kept_indices` is sorted, this is a
-    # binary search, which replaces a cumulative sum over all dense slots.
+    # A new pointer is the count of kept fragments before the dense position. A
+    # binary search gives this count and replaces a dense cumulative sum.
     dense_start_idx = precursor_df.frag_start_idx.values.astype(np.int64)
     dense_stop_idx = precursor_df.frag_stop_idx.values.astype(np.int64)
     precursor_df["flat_frag_start_idx"] = np.searchsorted(

--- a/alphabase/peptide/fragment.py
+++ b/alphabase/peptide/fragment.py
@@ -805,8 +805,8 @@ def mask_fragments_for_charge_greater_than_precursor_charge(
 def fill_in_indices(
     frag_start_idxes: np.ndarray,
     frag_stop_idxes: np.ndarray,
-    indices: np.ndarray,
-    max_indices: np.ndarray,
+    row_positions: np.ndarray,
+    row_counts: np.ndarray,
     excluded_indices: np.ndarray,
     top_k: int,
     flattened_intensity: np.ndarray,
@@ -814,9 +814,9 @@ def fill_in_indices(
     max_frag_per_peptide: int = 300,
 ) -> None:
     """
-    Fill in indices, max indices and excluded indices for each peptide.
-    indices: index of fragment per peptide (from 0 to max_index-1)
-    max_indices: max index of fragments per peptide (number of fragments per peptide)
+    Fill in row positions, row counts and excluded indices for each peptide.
+    row_positions: index of the fragment row within its peptide (from 0 to row count - 1)
+    row_counts: number of fragment rows of the peptide
     excluded_indices: not top k excluded indices per peptide
 
     Parameters
@@ -827,11 +827,13 @@ def fill_in_indices(
     frag_stop_idxes : np.ndarray
         stop indices of fragments for each peptide
 
-    indices : np.ndarray
-        index of fragment per peptide (from 0 to max_index-1) it will be filled in this function
+    row_positions : np.ndarray
+        index of the fragment row within its peptide, one value per fragment row.
+        It will be filled in this function.
 
-    max_indices : np.ndarray
-        max index of fragments per peptide (number of fragments per peptide) it will be filled in this function
+    row_counts : np.ndarray
+        number of fragment rows of the peptide, one value per fragment row.
+        It will be filled in this function.
 
     excluded_indices : np.ndarray
         not top k excluded indices per peptide it will be filled in this function
@@ -849,16 +851,16 @@ def fill_in_indices(
         maximum number of fragments per peptide, Defaults to 300
 
     """
-    array = np.arange(0, max_frag_per_peptide).reshape(-1, 1)
+    array = np.arange(0, max_frag_per_peptide)
     length = len(frag_start_idxes)
 
     for i in numba_prange(length):
         frag_start = frag_start_idxes[i]
         frag_end = frag_stop_idxes[i]
-        max_index = frag_end - frag_start
-        indices[frag_start:frag_end] = array[:max_index]
-        max_indices[frag_start:frag_end] = max_index
-        if flattened_intensity is None or top_k >= max_index * number_of_fragment_types:
+        row_count = frag_end - frag_start
+        row_positions[frag_start:frag_end] = array[:row_count]
+        row_counts[frag_start:frag_end] = row_count
+        if flattened_intensity is None or top_k >= row_count * number_of_fragment_types:
             continue
         idxes = np.argsort(
             flattened_intensity[
@@ -873,56 +875,57 @@ def fill_in_indices(
         ] = _excl
 
 
-@numba_vectorize(
-    [nb_.uint16(nb_.int8, nb_.uint16, nb_.uint16, nb_.uint16)], target="parallel"
-)
+@numba_vectorize([nb_.uint32(nb_.int8, nb_.uint16, nb_.uint16)], target="parallel")
 def calculate_fragment_numbers(
     frag_direction: np.int8,
-    frag_number: np.uint16,
-    index: np.uint16,
-    max_index: np.uint16,
+    row_position: np.uint16,
+    row_count: np.uint16,
 ):
     """
-    Calculate fragment numbers for each fragment based on the fragment direction.
+    Calculate the number of a fragment in its ion series.
 
     Parameters
     ----------
     frag_direction : np.int8
-        directions of fragments for each peptide
+        direction of the fragment type. 'abc' ions count from the first amino
+        acid, 'xyz' ions from the last one.
 
-    frag_number : np.uint16
-        fragment numbers for each peptide
+    row_position : np.uint16
+        index of the fragment row within its peptide
 
-    index : np.uint16
-        index of fragment per peptide (from 0 to max_index-1)
+    row_count : np.uint16
+        number of fragment rows of the peptide
 
-    max_index : np.uint16
-        max index of fragments per peptide (number of fragments per peptide)
+    Returns
+    -------
+    np.uint32
+        number of the fragment in its ion series, and 0 for direction 0
+
     """
     if frag_direction == 1:
-        frag_number = index + 1
-    elif frag_direction == -1:
-        frag_number = max_index - index
-    return frag_number
+        return row_position + 1
+    if frag_direction == -1:
+        return row_count - row_position
+    return 0
 
 
 def parse_fragment(
-    frag_directions: np.ndarray,
     frag_start_idxes: np.ndarray,
     frag_stop_idxes: np.ndarray,
     top_k: int,
     intensities: np.ndarray,
+    n_fragment_rows: int,
     number_of_fragment_types: int,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
-    Parse fragments to get fragment numbers, fragment positions and not top k excluded indices in one hit
+    Parse fragments to get row positions, row counts and not top k excluded indices in one hit
     faster than doing each operation individually, and makes the most of the operations that are done in parallel.
+
+    Row positions and row counts hold one value per fragment row instead of one
+    per dense slot, because every charged fragment type of a row shares them.
 
     Parameters
     ----------
-    frag_directions : np.ndarray
-        directions of fragments for each peptide
-
     frag_start_idxes : np.ndarray
         start indices of fragments for each peptide
 
@@ -935,43 +938,40 @@ def parse_fragment(
     intensities : np.ndarray
         Flattened fragment intensities
 
+    n_fragment_rows : int
+        number of rows of the dense fragment dataframes
+
     number_of_fragment_types : int
         number of types of fragments (e.g. b,y,b_modloss,y_modloss, ...) equals to the number of columns in fragment mz dataframe
 
     Returns
     -------
     Tuple[np.ndarray, np.ndarray, np.ndarray]
-        Tuple of fragment numbers (uint16), fragment positions (uint16) and not
-        top k excluded indices (bool)
+        Tuple of the row position (uint16) and the row count (uint16) of every
+        fragment row, and the not top k excluded indices (bool) of every dense slot
 
     """
     # uint16 holds every value, because `max_frag_per_peptide` of
-    # `fill_in_indices` bounds the fragment numbers and indices. A wider dtype
-    # would cost 2 more bytes per dense slot.
-    frag_numbers = np.empty_like(frag_directions, dtype=np.uint16)
-    indices = np.empty_like(frag_directions, dtype=np.uint16)
-    max_indices = np.empty_like(frag_directions, dtype=np.uint16)
+    # `fill_in_indices` bounds the row positions and the row counts. Rows that no
+    # peptide covers keep a zero.
+    row_positions = np.zeros(n_fragment_rows, dtype=np.uint16)
+    row_counts = np.zeros(n_fragment_rows, dtype=np.uint16)
     excluded_indices = np.zeros(
-        frag_directions.shape[0] * frag_directions.shape[1], dtype=np.bool_
+        n_fragment_rows * number_of_fragment_types, dtype=np.bool_
     )
 
-    # Fill in indices, max indices and excluded indices
     fill_in_indices(
         frag_start_idxes,
         frag_stop_idxes,
-        indices,
-        max_indices,
+        row_positions,
+        row_counts,
         excluded_indices,
         top_k,
         intensities,
         number_of_fragment_types,
     )
 
-    # Calculate fragment numbers
-    frag_numbers = calculate_fragment_numbers(
-        frag_directions, frag_numbers, indices, max_indices
-    )
-    return frag_numbers, indices, excluded_indices
+    return row_positions, row_counts, excluded_indices
 
 
 def _annotate_charged_frag_types(
@@ -1014,13 +1014,12 @@ def _select_dense_fragments(
     precursor_df: pd.DataFrame,
     mz: np.ndarray,
     intensity: Union[np.ndarray, None],
-    directions: np.ndarray,
     n_fragment_rows: int,
     n_fragment_types: int,
     keep_top_k_fragments: int,
     min_fragment_intensity: float,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Select the dense fragment slots to keep, and number every dense slot.
+    """Select the dense fragment slots to keep, and locate every fragment row.
 
     A slot is excluded if it holds padding (`mz == 0`), if its intensity is below
     `min_fragment_intensity`, or if it is not one of the `keep_top_k_fragments`
@@ -1035,11 +1034,7 @@ def _select_dense_fragments(
         flattened fragment mz values, of length n_fragment_rows * n_fragment_types
 
     intensity : np.ndarray or None
-        flattened fragment intensities, or None to filter on mz only.
-        Padding slots are set to zero intensity.
-
-    directions : np.ndarray
-        direction of every charged fragment type
+        flattened fragment intensities, or None to filter on mz only
 
     n_fragment_rows : int
         number of rows of the dense fragment dataframes
@@ -1056,39 +1051,108 @@ def _select_dense_fragments(
     Returns
     -------
     Tuple[np.ndarray, np.ndarray, np.ndarray]
-        ascending indices of the kept slots, and the fragment number and position
-        of every dense slot
+        ascending indices of the kept slots, and the row position and the row
+        count of every fragment row
 
     """
-    # tile the int8 directions, because a tiled list gives a dense int64 array
-    dense_directions = np.tile(directions, (n_fragment_rows, 1))
-
-    numbers, positions, not_top_k = parse_fragment(
-        dense_directions,
+    row_positions, row_counts, not_top_k = parse_fragment(
         precursor_df.frag_start_idx.values,
         precursor_df.frag_stop_idx.values,
         keep_top_k_fragments,
         intensity,
+        n_fragment_rows,
         n_fragment_types,
     )
-    del dense_directions
 
     if intensity is None:
         excluded = mz == 0
     else:
-        is_padding = mz == 0
-        intensity[is_padding] = 0.0
         # in-place operations prevent more dense boolean arrays
         excluded = intensity < min_fragment_intensity
-        excluded |= is_padding
+        excluded |= mz == 0
         excluded |= not_top_k
-        del is_padding
     del not_top_k
 
     # The in-place inversion prevents one more dense array. The indices stay
     # ascending, so the fragments keep their dense order.
     np.logical_not(excluded, out=excluded)
-    return np.flatnonzero(excluded), numbers, positions
+    return np.flatnonzero(excluded), row_positions, row_counts
+
+
+def _annotate_kept_fragments(
+    kept_indices: np.ndarray,
+    row_positions: np.ndarray,
+    row_counts: np.ndarray,
+    series_ids: np.ndarray,
+    loss_ids: np.ndarray,
+    charges: np.ndarray,
+    directions: np.ndarray,
+    n_fragment_types: int,
+    custom_columns: list,
+) -> Dict[str, np.ndarray]:
+    """Give the requested annotation columns of the kept fragments.
+
+    The index of a kept slot gives both its fragment row and its charged fragment
+    type, so the annotations need no dense array.
+
+    Parameters
+    ----------
+    kept_indices : np.ndarray
+        ascending indices of the kept dense slots
+
+    row_positions : np.ndarray
+        index of the fragment row within its precursor, one value per fragment row
+
+    row_counts : np.ndarray
+        number of fragment rows of the precursor, one value per fragment row
+
+    series_ids : np.ndarray
+        series id of every charged fragment type
+
+    loss_ids : np.ndarray
+        loss id of every charged fragment type
+
+    charges : np.ndarray
+        charge of every charged fragment type
+
+    directions : np.ndarray
+        direction of every charged fragment type
+
+    n_fragment_types : int
+        number of charged fragment types, that is the number of dense columns
+
+    custom_columns : list
+        names of the annotation columns to create
+
+    Returns
+    -------
+    Dict[str, np.ndarray]
+        the requested columns, in the column order of the flat fragment dataframe
+
+    """
+    needs_frag_type = bool(
+        {"type", "loss_type", "charge", "number"}.intersection(custom_columns)
+    )
+    needs_row = bool({"number", "position"}.intersection(custom_columns))
+    kept_frag_types = kept_indices % n_fragment_types if needs_frag_type else None
+    kept_rows = kept_indices // n_fragment_types if needs_row else None
+
+    columns = {}
+    if "type" in custom_columns:
+        columns["type"] = series_ids[kept_frag_types]
+    if "loss_type" in custom_columns:
+        columns["loss_type"] = loss_ids[kept_frag_types]
+    if "charge" in custom_columns:
+        columns["charge"] = charges[kept_frag_types]
+    if "number" in custom_columns:
+        columns["number"] = calculate_fragment_numbers(
+            directions[kept_frag_types], row_positions[kept_rows], row_counts[kept_rows]
+        )
+    if "position" in custom_columns:
+        # the flat column keeps its uint32 dtype
+        columns["position"] = row_positions[kept_rows].astype(np.uint32)
+
+    return columns
 
 
 def _reannotate_precursor_pointers(
@@ -1196,8 +1260,13 @@ def flatten_fragments(
     # fills most dense slots.
     mz = fragment_mz_df.values.reshape(-1)
     use_intensity = len(fragment_intensity_df) > 0
+    # `copy=False` keeps a dense copy out of memory whenever the dtype already
+    # matches. Nothing writes to `mz` or `intensity`, so both stay views on the
+    # input dataframes.
     intensity = (
-        fragment_intensity_df.values.astype(PEAK_INTENSITY_DTYPE).reshape(-1)
+        fragment_intensity_df.values.astype(PEAK_INTENSITY_DTYPE, copy=False).reshape(
+            -1
+        )
         if use_intensity
         else None
     )
@@ -1206,11 +1275,10 @@ def flatten_fragments(
         fragment_mz_df.columns.values
     )
 
-    kept_indices, numbers, positions = _select_dense_fragments(
+    kept_indices, row_positions, row_counts = _select_dense_fragments(
         precursor_df,
         mz,
         intensity,
-        directions,
         len(fragment_mz_df),
         n_fragment_types,
         keep_top_k_fragments,
@@ -1224,24 +1292,19 @@ def flatten_fragments(
     # each custom_df value is a dense dataframe
     for col_name, df in custom_df.items():
         frag_df[col_name] = df.values.reshape(-1)[kept_indices]
-
-    if {"type", "loss_type", "charge"} & set(custom_columns):
-        # the column of a dense slot gives its charged fragment type
-        kept_frag_types = kept_indices % n_fragment_types
-        if "type" in custom_columns:
-            frag_df["type"] = series_ids[kept_frag_types]
-        if "loss_type" in custom_columns:
-            frag_df["loss_type"] = loss_ids[kept_frag_types]
-        if "charge" in custom_columns:
-            frag_df["charge"] = charges[kept_frag_types]
-        del kept_frag_types
-
-    # the dense arrays are uint16, but the flat columns keep their uint32 dtype
-    if "number" in custom_columns:
-        frag_df["number"] = numbers.reshape(-1)[kept_indices].astype(np.uint32)
-
-    if "position" in custom_columns:
-        frag_df["position"] = positions.reshape(-1)[kept_indices].astype(np.uint32)
+    frag_df.update(
+        _annotate_kept_fragments(
+            kept_indices,
+            row_positions,
+            row_counts,
+            series_ids,
+            loss_ids,
+            charges,
+            directions,
+            n_fragment_types,
+            custom_columns,
+        )
+    )
 
     _reannotate_precursor_pointers(precursor_df, kept_indices, n_fragment_types)
 

--- a/alphabase/peptide/fragment.py
+++ b/alphabase/peptide/fragment.py
@@ -850,7 +850,6 @@ def fill_in_indices(
 
     """
     array = np.arange(0, max_frag_per_peptide).reshape(-1, 1)
-    ones = np.ones(max_frag_per_peptide).reshape(-1, 1)
     length = len(frag_start_idxes)
 
     for i in numba_prange(length):
@@ -858,7 +857,7 @@ def fill_in_indices(
         frag_end = frag_stop_idxes[i]
         max_index = frag_end - frag_start
         indices[frag_start:frag_end] = array[:max_index]
-        max_indices[frag_start:frag_end] = ones[:max_index] * max_index
+        max_indices[frag_start:frag_end] = max_index
         if flattened_intensity is None or top_k >= max_index * number_of_fragment_types:
             continue
         idxes = np.argsort(
@@ -875,13 +874,13 @@ def fill_in_indices(
 
 
 @numba_vectorize(
-    [nb_.uint32(nb_.int8, nb_.uint32, nb_.uint32, nb_.uint32)], target="parallel"
+    [nb_.uint16(nb_.int8, nb_.uint16, nb_.uint16, nb_.uint16)], target="parallel"
 )
 def calculate_fragment_numbers(
     frag_direction: np.int8,
-    frag_number: np.uint32,
-    index: np.uint32,
-    max_index: np.uint32,
+    frag_number: np.uint16,
+    index: np.uint16,
+    max_index: np.uint16,
 ):
     """
     Calculate fragment numbers for each fragment based on the fragment direction.
@@ -891,13 +890,13 @@ def calculate_fragment_numbers(
     frag_direction : np.int8
         directions of fragments for each peptide
 
-    frag_number : np.uint32
+    frag_number : np.uint16
         fragment numbers for each peptide
 
-    index : np.uint32
+    index : np.uint16
         index of fragment per peptide (from 0 to max_index-1)
 
-    max_index : np.uint32
+    max_index : np.uint16
         max index of fragments per peptide (number of fragments per peptide)
     """
     if frag_direction == 1:
@@ -942,13 +941,16 @@ def parse_fragment(
     Returns
     -------
     Tuple[np.ndarray, np.ndarray, np.ndarray]
-        Tuple of fragment numbers, fragment positions and not top k excluded indices
+        Tuple of fragment numbers (uint16), fragment positions (uint16) and not
+        top k excluded indices (bool)
 
     """
-    # Allocate memory for fragment numbers, indices, max indices and excluded indices
-    frag_numbers = np.empty_like(frag_directions, dtype=np.uint32)
-    indices = np.empty_like(frag_directions, dtype=np.uint32)
-    max_indices = np.empty_like(frag_directions, dtype=np.uint32)
+    # uint16 holds every value, because `max_frag_per_peptide` of
+    # `fill_in_indices` bounds the fragment numbers and indices. A wider dtype
+    # would cost 2 more bytes per dense slot.
+    frag_numbers = np.empty_like(frag_directions, dtype=np.uint16)
+    indices = np.empty_like(frag_directions, dtype=np.uint16)
+    max_indices = np.empty_like(frag_directions, dtype=np.uint16)
     excluded_indices = np.zeros(
         frag_directions.shape[0] * frag_directions.shape[1], dtype=np.bool_
     )
@@ -1234,11 +1236,12 @@ def flatten_fragments(
             frag_df["charge"] = charges[kept_frag_types]
         del kept_frag_types
 
+    # the dense arrays are uint16, but the flat columns keep their uint32 dtype
     if "number" in custom_columns:
-        frag_df["number"] = numbers.reshape(-1)[kept_indices]
+        frag_df["number"] = numbers.reshape(-1)[kept_indices].astype(np.uint32)
 
     if "position" in custom_columns:
-        frag_df["position"] = positions.reshape(-1)[kept_indices]
+        frag_df["position"] = positions.reshape(-1)[kept_indices].astype(np.uint32)
 
     _reannotate_precursor_pointers(precursor_df, kept_indices, n_fragment_types)
 

--- a/alphabase/peptide/fragment.py
+++ b/alphabase/peptide/fragment.py
@@ -1037,20 +1037,24 @@ def flatten_fragments(
     """
     if len(precursor_df) == 0:
         return precursor_df, pd.DataFrame()
-    # new dataframes for fragments and precursors are created
-    frag_df = {}
-    frag_df["mz"] = fragment_mz_df.values.reshape(-1)
-    if len(fragment_intensity_df) > 0:
-        frag_df["intensity"] = fragment_intensity_df.values.astype(
-            PEAK_INTENSITY_DTYPE
-        ).reshape(-1)
-        use_intensity = True
-    else:
-        use_intensity = False
-    # add additional columns to the fragment dataframe
-    # each column in the flat fragment dataframe is a whole pandas dataframe in the dense representation
-    for col_name, df in custom_df.items():
-        frag_df[col_name] = df.values.reshape(-1)
+
+    n_fragment_types = len(fragment_mz_df.columns)
+
+    # Only `mz` and `intensity` are required at the full dense length of
+    # n_fragment_rows * n_fragment_types, as they determine which fragments are
+    # retained. Every other flat column is built directly from the indices of the
+    # retained fragments, so neither the dense intermediates for
+    # type/loss_type/charge/number/position nor the copy that filtering an
+    # assembled dataframe would make are ever materialised. Peak memory is thus
+    # driven by the number of retained fragments instead of the number of dense
+    # slots, which for top-k libraries is dominated by mz==0 padding.
+    mz = fragment_mz_df.values.reshape(-1)
+    use_intensity = len(fragment_intensity_df) > 0
+    intensity = (
+        fragment_intensity_df.values.astype(PEAK_INTENSITY_DTYPE).reshape(-1)
+        if use_intensity
+        else None
+    )
 
     frag_types = []
     frag_loss_types = []
@@ -1064,72 +1068,80 @@ def flatten_fragments(
         frag_loss_types.append(FRAGMENT_TYPES[frag_type].loss_id)
         frag_directions.append(FRAGMENT_TYPES[frag_type].direction_id)
 
-    if "type" in custom_columns:
-        frag_df["type"] = np.array(
-            np.tile(frag_types, len(fragment_mz_df)), dtype=np.int8
-        )
-    if "loss_type" in custom_columns:
-        frag_df["loss_type"] = np.array(
-            np.tile(frag_loss_types, len(fragment_mz_df)), dtype=np.int16
-        )
-    if "charge" in custom_columns:
-        frag_df["charge"] = np.array(
-            np.tile(frag_charges, len(fragment_mz_df)), dtype=np.int8
-        )
-
-    frag_directions = np.array(
+    dense_frag_directions = np.array(
         np.tile(frag_directions, (len(fragment_mz_df), 1)), dtype=np.int8
     )
 
     numbers, positions, excluded_indices = parse_fragment(
-        frag_directions,
+        dense_frag_directions,
         precursor_df.frag_start_idx.values,
         precursor_df.frag_stop_idx.values,
         keep_top_k_fragments,
-        frag_df["intensity"] if use_intensity else None,
-        len(fragment_mz_df.columns),
+        intensity,
+        n_fragment_types,
     )
-
-    if "number" in custom_columns:
-        frag_df["number"] = numbers.reshape(-1)
-
-    if "position" in custom_columns:
-        frag_df["position"] = positions.reshape(-1)
-
-    precursor_df["flat_frag_start_idx"] = precursor_df.frag_start_idx
-    precursor_df["flat_frag_stop_idx"] = precursor_df.frag_stop_idx
-    precursor_df[["flat_frag_start_idx", "flat_frag_stop_idx"]] *= len(
-        fragment_mz_df.columns
-    )
+    del dense_frag_directions
 
     if use_intensity:
-        frag_df["intensity"][frag_df["mz"] == 0.0] = 0.0
+        is_padding = mz == 0
+        intensity[is_padding] = 0.0
+        # accumulated in place to avoid intermediate dense boolean arrays
+        excluded = intensity < min_fragment_intensity
+        excluded |= is_padding
+        excluded |= excluded_indices
+        del is_padding
+    else:
+        excluded = mz == 0
+    del excluded_indices
 
-    excluded = (
-        frag_df["mz"] == 0
-        if not use_intensity
-        else (frag_df["intensity"] < min_fragment_intensity)
-        | (frag_df["mz"] == 0)
-        | (excluded_indices)
+    # `excluded` is inverted in place into the keep mask, which saves another
+    # dense boolean array. The resulting indices are ascending, so indexing with
+    # them retains the fragment order of the dense representation.
+    np.logical_not(excluded, out=excluded)
+    kept_indices = np.flatnonzero(excluded)
+    del excluded
+
+    frag_df = {}
+    frag_df["mz"] = mz[kept_indices]
+    if use_intensity:
+        frag_df["intensity"] = intensity[kept_indices]
+    # add additional columns to the fragment dataframe
+    # each column in the flat fragment dataframe is a whole pandas dataframe in the dense representation
+    for col_name, df in custom_df.items():
+        frag_df[col_name] = df.values.reshape(-1)[kept_indices]
+
+    if {"type", "loss_type", "charge"} & set(custom_columns):
+        # the charged fragment type of a dense slot is given by its column
+        kept_frag_types = kept_indices % n_fragment_types
+        if "type" in custom_columns:
+            frag_df["type"] = np.array(frag_types, dtype=np.int8)[kept_frag_types]
+        if "loss_type" in custom_columns:
+            frag_df["loss_type"] = np.array(frag_loss_types, dtype=np.int16)[
+                kept_frag_types
+            ]
+        if "charge" in custom_columns:
+            frag_df["charge"] = np.array(frag_charges, dtype=np.int8)[kept_frag_types]
+        del kept_frag_types
+
+    if "number" in custom_columns:
+        frag_df["number"] = numbers.reshape(-1)[kept_indices]
+
+    if "position" in custom_columns:
+        frag_df["position"] = positions.reshape(-1)[kept_indices]
+
+    # The reannotated pointer of a precursor is the number of retained fragments
+    # before its dense start/stop position. As `kept_indices` is sorted, this is a
+    # binary search, which replaces a cumulative sum over all dense slots.
+    dense_start_idx = precursor_df.frag_start_idx.values.astype(np.int64)
+    dense_stop_idx = precursor_df.frag_stop_idx.values.astype(np.int64)
+    precursor_df["flat_frag_start_idx"] = np.searchsorted(
+        kept_indices, dense_start_idx * n_fragment_types
+    )
+    precursor_df["flat_frag_stop_idx"] = np.searchsorted(
+        kept_indices, dense_stop_idx * n_fragment_types
     )
 
-    frag_df = pd.DataFrame(frag_df)
-    frag_df = frag_df[~excluded]
-    frag_df = frag_df.reset_index(drop=True)
-
-    # cumulative sum counts the number of fragments before the given fragment which were removed.
-    # This sum does not include the fragment at the index position and has therefore len N +1
-    cum_sum_tresh = np.zeros(shape=len(excluded) + 1, dtype=np.int64)
-    cum_sum_tresh[1:] = np.cumsum(excluded)
-
-    precursor_df["flat_frag_start_idx"] -= cum_sum_tresh[
-        precursor_df.flat_frag_start_idx.values
-    ]
-    precursor_df["flat_frag_stop_idx"] -= cum_sum_tresh[
-        precursor_df.flat_frag_stop_idx.values
-    ]
-
-    return precursor_df, frag_df
+    return precursor_df, pd.DataFrame(frag_df, copy=False)
 
 
 @numba_njit

--- a/alphabase/peptide/fragment.py
+++ b/alphabase/peptide/fragment.py
@@ -972,6 +972,154 @@ def parse_fragment(
     return frag_numbers, indices, excluded_indices
 
 
+def _annotate_charged_frag_types(
+    charged_frag_types: np.ndarray,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Give the series id, loss id, charge and direction of every charged fragment type.
+
+    Parameters
+    ----------
+    charged_frag_types : np.ndarray
+        names of the charged fragment types, in the order of the dense columns
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+        series ids, loss ids, charges and directions, one value per charged fragment type
+
+    """
+    series_ids = []
+    loss_ids = []
+    charges = []
+    directions = []  # 'abc': direction=1, 'xyz': direction=-1, otherwise 0
+
+    for charged_frag_type in charged_frag_types:
+        frag_type, charge = parse_charged_frag_type(charged_frag_type)
+        series_ids.append(FRAGMENT_TYPES[frag_type].series_id)
+        loss_ids.append(FRAGMENT_TYPES[frag_type].loss_id)
+        charges.append(charge)
+        directions.append(FRAGMENT_TYPES[frag_type].direction_id)
+
+    return (
+        np.array(series_ids, dtype=np.int8),
+        np.array(loss_ids, dtype=np.int16),
+        np.array(charges, dtype=np.int8),
+        np.array(directions, dtype=np.int8),
+    )
+
+
+def _select_dense_fragments(
+    precursor_df: pd.DataFrame,
+    mz: np.ndarray,
+    intensity: Union[np.ndarray, None],
+    directions: np.ndarray,
+    n_fragment_rows: int,
+    n_fragment_types: int,
+    keep_top_k_fragments: int,
+    min_fragment_intensity: float,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Select the dense fragment slots to keep, and number every dense slot.
+
+    A slot is excluded if it holds padding (`mz == 0`), if its intensity is below
+    `min_fragment_intensity`, or if it is not one of the `keep_top_k_fragments`
+    most intense slots of its precursor.
+
+    Parameters
+    ----------
+    precursor_df : pd.DataFrame
+        precursor dataframe with the `frag_start_idx` and `frag_stop_idx` columns
+
+    mz : np.ndarray
+        flattened fragment mz values, of length n_fragment_rows * n_fragment_types
+
+    intensity : np.ndarray or None
+        flattened fragment intensities, or None to filter on mz only.
+        Padding slots are set to zero intensity.
+
+    directions : np.ndarray
+        direction of every charged fragment type
+
+    n_fragment_rows : int
+        number of rows of the dense fragment dataframes
+
+    n_fragment_types : int
+        number of charged fragment types, that is the number of dense columns
+
+    keep_top_k_fragments : int
+        number of most intense slots to keep per precursor
+
+    min_fragment_intensity : float
+        minimum intensity of a slot to keep
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray, np.ndarray]
+        ascending indices of the kept slots, and the fragment number and position
+        of every dense slot
+
+    """
+    # tile the int8 directions, because a tiled list gives a dense int64 array
+    dense_directions = np.tile(directions, (n_fragment_rows, 1))
+
+    numbers, positions, not_top_k = parse_fragment(
+        dense_directions,
+        precursor_df.frag_start_idx.values,
+        precursor_df.frag_stop_idx.values,
+        keep_top_k_fragments,
+        intensity,
+        n_fragment_types,
+    )
+    del dense_directions
+
+    if intensity is None:
+        excluded = mz == 0
+    else:
+        is_padding = mz == 0
+        intensity[is_padding] = 0.0
+        # in-place operations prevent more dense boolean arrays
+        excluded = intensity < min_fragment_intensity
+        excluded |= is_padding
+        excluded |= not_top_k
+        del is_padding
+    del not_top_k
+
+    # The in-place inversion prevents one more dense array. The indices stay
+    # ascending, so the fragments keep their dense order.
+    np.logical_not(excluded, out=excluded)
+    return np.flatnonzero(excluded), numbers, positions
+
+
+def _reannotate_precursor_pointers(
+    precursor_df: pd.DataFrame, kept_indices: np.ndarray, n_fragment_types: int
+) -> None:
+    """Add the flat fragment pointers to `precursor_df`, in place.
+
+    A new pointer is the count of kept fragments before the dense position. A
+    binary search on the ascending `kept_indices` gives this count and replaces a
+    dense cumulative sum.
+
+    Parameters
+    ----------
+    precursor_df : pd.DataFrame
+        precursor dataframe with the `frag_start_idx` and `frag_stop_idx` columns
+
+    kept_indices : np.ndarray
+        ascending indices of the kept dense slots
+
+    n_fragment_types : int
+        number of charged fragment types, that is the number of dense columns
+
+    """
+    dense_start_idx = precursor_df.frag_start_idx.values.astype(np.int64)
+    dense_stop_idx = precursor_df.frag_stop_idx.values.astype(np.int64)
+    precursor_df["flat_frag_start_idx"] = np.searchsorted(
+        kept_indices, dense_start_idx * n_fragment_types
+    )
+    precursor_df["flat_frag_stop_idx"] = np.searchsorted(
+        kept_indices, dense_stop_idx * n_fragment_types
+    )
+
+
 def flatten_fragments(
     precursor_df: pd.DataFrame,
     fragment_mz_df: pd.DataFrame,
@@ -1052,49 +1200,20 @@ def flatten_fragments(
         else None
     )
 
-    frag_types = []
-    frag_loss_types = []
-    frag_charges = []
-    frag_directions = []  # 'abc': direction=1, 'xyz': direction=-1, otherwise 0
-
-    for charged_frag_type in fragment_mz_df.columns.values:
-        frag_type, charge = parse_charged_frag_type(charged_frag_type)
-        frag_charges.append(charge)
-        frag_types.append(FRAGMENT_TYPES[frag_type].series_id)
-        frag_loss_types.append(FRAGMENT_TYPES[frag_type].loss_id)
-        frag_directions.append(FRAGMENT_TYPES[frag_type].direction_id)
-
-    dense_frag_directions = np.array(
-        np.tile(frag_directions, (len(fragment_mz_df), 1)), dtype=np.int8
+    series_ids, loss_ids, charges, directions = _annotate_charged_frag_types(
+        fragment_mz_df.columns.values
     )
 
-    numbers, positions, excluded_indices = parse_fragment(
-        dense_frag_directions,
-        precursor_df.frag_start_idx.values,
-        precursor_df.frag_stop_idx.values,
-        keep_top_k_fragments,
+    kept_indices, numbers, positions = _select_dense_fragments(
+        precursor_df,
+        mz,
         intensity,
+        directions,
+        len(fragment_mz_df),
         n_fragment_types,
+        keep_top_k_fragments,
+        min_fragment_intensity,
     )
-    del dense_frag_directions
-
-    if use_intensity:
-        is_padding = mz == 0
-        intensity[is_padding] = 0.0
-        # in-place operations prevent more dense boolean arrays
-        excluded = intensity < min_fragment_intensity
-        excluded |= is_padding
-        excluded |= excluded_indices
-        del is_padding
-    else:
-        excluded = mz == 0
-    del excluded_indices
-
-    # The in-place inversion prevents one more dense array. The indices stay
-    # ascending, so the fragments keep their dense order.
-    np.logical_not(excluded, out=excluded)
-    kept_indices = np.flatnonzero(excluded)
-    del excluded
 
     frag_df = {}
     frag_df["mz"] = mz[kept_indices]
@@ -1108,13 +1227,11 @@ def flatten_fragments(
         # the column of a dense slot gives its charged fragment type
         kept_frag_types = kept_indices % n_fragment_types
         if "type" in custom_columns:
-            frag_df["type"] = np.array(frag_types, dtype=np.int8)[kept_frag_types]
+            frag_df["type"] = series_ids[kept_frag_types]
         if "loss_type" in custom_columns:
-            frag_df["loss_type"] = np.array(frag_loss_types, dtype=np.int16)[
-                kept_frag_types
-            ]
+            frag_df["loss_type"] = loss_ids[kept_frag_types]
         if "charge" in custom_columns:
-            frag_df["charge"] = np.array(frag_charges, dtype=np.int8)[kept_frag_types]
+            frag_df["charge"] = charges[kept_frag_types]
         del kept_frag_types
 
     if "number" in custom_columns:
@@ -1123,16 +1240,7 @@ def flatten_fragments(
     if "position" in custom_columns:
         frag_df["position"] = positions.reshape(-1)[kept_indices]
 
-    # A new pointer is the count of kept fragments before the dense position. A
-    # binary search gives this count and replaces a dense cumulative sum.
-    dense_start_idx = precursor_df.frag_start_idx.values.astype(np.int64)
-    dense_stop_idx = precursor_df.frag_stop_idx.values.astype(np.int64)
-    precursor_df["flat_frag_start_idx"] = np.searchsorted(
-        kept_indices, dense_start_idx * n_fragment_types
-    )
-    precursor_df["flat_frag_stop_idx"] = np.searchsorted(
-        kept_indices, dense_stop_idx * n_fragment_types
-    )
+    _reannotate_precursor_pointers(precursor_df, kept_indices, n_fragment_types)
 
     return precursor_df, pd.DataFrame(frag_df, copy=False)
 

--- a/alphabase/peptide/fragment.py
+++ b/alphabase/peptide/fragment.py
@@ -802,7 +802,7 @@ def mask_fragments_for_charge_greater_than_precursor_charge(
 
 
 @numba_njit(parallel=True)
-def fill_in_indices(
+def _fill_in_indices(
     frag_start_idxes: np.ndarray,
     frag_stop_idxes: np.ndarray,
     row_positions: np.ndarray,
@@ -876,7 +876,7 @@ def fill_in_indices(
 
 
 @numba_vectorize([nb_.uint32(nb_.int8, nb_.uint16, nb_.uint16)], target="parallel")
-def calculate_fragment_numbers(
+def _calculate_fragment_numbers(
     frag_direction: np.int8,
     row_position: np.uint16,
     row_count: np.uint16,
@@ -909,7 +909,7 @@ def calculate_fragment_numbers(
     return 0
 
 
-def parse_fragment(
+def _parse_fragment(
     frag_start_idxes: np.ndarray,
     frag_stop_idxes: np.ndarray,
     top_k: int,
@@ -952,7 +952,7 @@ def parse_fragment(
 
     """
     # uint16 holds every value, because `max_frag_per_peptide` of
-    # `fill_in_indices` bounds the row positions and the row counts. Rows that no
+    # `_fill_in_indices` bounds the row positions and the row counts. Rows that no
     # peptide covers keep a zero.
     row_positions = np.zeros(n_fragment_rows, dtype=np.uint16)
     row_counts = np.zeros(n_fragment_rows, dtype=np.uint16)
@@ -960,7 +960,7 @@ def parse_fragment(
         n_fragment_rows * number_of_fragment_types, dtype=np.bool_
     )
 
-    fill_in_indices(
+    _fill_in_indices(
         frag_start_idxes,
         frag_stop_idxes,
         row_positions,
@@ -1055,7 +1055,7 @@ def _select_dense_fragments(
         count of every fragment row
 
     """
-    row_positions, row_counts, not_top_k = parse_fragment(
+    row_positions, row_counts, not_top_k = _parse_fragment(
         precursor_df.frag_start_idx.values,
         precursor_df.frag_stop_idx.values,
         keep_top_k_fragments,
@@ -1145,7 +1145,7 @@ def _annotate_kept_fragments(
     if "charge" in custom_columns:
         columns["charge"] = charges[kept_frag_types]
     if "number" in custom_columns:
-        columns["number"] = calculate_fragment_numbers(
+        columns["number"] = _calculate_fragment_numbers(
             directions[kept_frag_types], row_positions[kept_rows], row_counts[kept_rows]
         )
     if "position" in custom_columns:

--- a/tests/unit/peptide/test_fragment.py
+++ b/tests/unit/peptide/test_fragment.py
@@ -8,9 +8,11 @@ from alphabase.peptide.fragment import (
     FRAGMENT_TYPES,
     PEAK_INTENSITY_DTYPE,
     PEAK_MZ_DTYPE,
+    calculate_fragment_numbers,
     filter_valid_charged_frag_types,
     flatten_fragments,
     parse_charged_frag_type,
+    parse_fragment,
 )
 
 
@@ -325,3 +327,35 @@ def test_flatten_fragments_long_precursor():
     assert frag_df["number"].max() == n_rows
     assert frag_df["position"].dtype == np.uint32
     assert frag_df["number"].dtype == np.uint32
+
+
+@pytest.mark.requires_numba
+def test_calculate_fragment_numbers_counts_from_both_ends():
+    """'abc' ions count from the first amino acid, 'xyz' ions from the last one."""
+    directions = np.array([1, -1, 0, 1, -1], dtype=np.int8)
+    row_positions = np.array([0, 0, 0, 3, 3], dtype=np.uint16)
+    row_counts = np.array([7, 7, 7, 7, 7], dtype=np.uint16)
+
+    numbers = calculate_fragment_numbers(directions, row_positions, row_counts)
+
+    np.testing.assert_array_equal(numbers, [1, 7, 0, 4, 4])
+    assert numbers.dtype == np.uint32
+
+
+@pytest.mark.requires_numba
+def test_parse_fragment_gives_one_value_per_fragment_row():
+    """Row positions and row counts hold one value per fragment row, not per dense slot."""
+    frag_start_idx = np.array([0, 3], dtype=np.int64)
+    frag_stop_idx = np.array([3, 7], dtype=np.int64)
+
+    row_positions, row_counts, not_top_k = parse_fragment(
+        frag_start_idx, frag_stop_idx, 1000, None, 7, 4
+    )
+
+    np.testing.assert_array_equal(row_positions, [0, 1, 2, 0, 1, 2, 3])
+    np.testing.assert_array_equal(row_counts, [3, 3, 3, 4, 4, 4, 4])
+    assert row_positions.dtype == np.uint16
+    assert row_counts.dtype == np.uint16
+    # one flag per dense slot, and nothing is excluded without intensities
+    assert len(not_top_k) == 7 * 4
+    assert not not_top_k.any()

--- a/tests/unit/peptide/test_fragment.py
+++ b/tests/unit/peptide/test_fragment.py
@@ -1,9 +1,15 @@
 from unittest.mock import patch
 
+import numpy as np
+import pandas as pd
 import pytest
 
 from alphabase.peptide.fragment import (
+    FRAGMENT_TYPES,
+    PEAK_INTENSITY_DTYPE,
+    PEAK_MZ_DTYPE,
     filter_valid_charged_frag_types,
+    flatten_fragments,
     parse_charged_frag_type,
 )
 
@@ -51,3 +57,245 @@ def test_filter_valid_charged_frag_types(mock_parse):
         )
     assert result == ["b_z1", "y_z2"]
     assert len(recorded_warnings) == 1  # Should have 2 warning messages
+
+
+CHARGED_FRAG_TYPES = [
+    "b_z1",
+    "b_z2",
+    "y_z1",
+    "y_z2",
+    "b_modloss_z1",
+    "y_modloss_z1",
+]
+ROWS_PER_PRECURSOR = 4
+N_PRECURSORS = 5
+
+
+def _dense_library():
+    """Dense fragment frames with padding, and the matching precursor pointers."""
+    rng = np.random.default_rng(0)
+    n_rows = N_PRECURSORS * ROWS_PER_PRECURSOR
+    n_types = len(CHARGED_FRAG_TYPES)
+
+    mz = (rng.random((n_rows, n_types)) * 1000 + 100).astype(PEAK_MZ_DTYPE)
+    # modloss fragments are not predicted for unmodified precursors and single
+    # fragments can fall outside the mz range: both appear as mz == 0 padding
+    mz[: 2 * ROWS_PER_PRECURSOR, 4:] = 0
+    mz[3, 0] = 0
+    # distinct intensities make the top-k selection unambiguous
+    intensity = rng.permutation(n_rows * n_types).reshape(n_rows, n_types)
+    intensity = (intensity / intensity.max()).astype(PEAK_INTENSITY_DTYPE)
+
+    frag_start_idx = np.arange(N_PRECURSORS) * ROWS_PER_PRECURSOR
+    precursor_df = pd.DataFrame(
+        {
+            "frag_start_idx": frag_start_idx,
+            "frag_stop_idx": frag_start_idx + ROWS_PER_PRECURSOR,
+        }
+    )
+    return (
+        precursor_df,
+        pd.DataFrame(mz, columns=CHARGED_FRAG_TYPES),
+        pd.DataFrame(intensity, columns=CHARGED_FRAG_TYPES),
+    )
+
+
+def _expected_keep_mask(
+    precursor_df, mz_df, intensity_df, keep_top_k_fragments, min_fragment_intensity
+):
+    """Keep mask over all dense slots, derived without using flatten_fragments."""
+    n_types = mz_df.shape[1]
+    mz = mz_df.values.reshape(-1)
+    intensity = None if len(intensity_df) == 0 else intensity_df.values.reshape(-1)
+
+    mask = np.zeros(mz.size, dtype=bool)
+    for start, stop in zip(precursor_df.frag_start_idx, precursor_df.frag_stop_idx):
+        block = slice(start * n_types, stop * n_types)
+        keep = mz[block] != 0
+        if intensity is not None:
+            keep &= intensity[block] >= min_fragment_intensity
+            n_slots = (stop - start) * n_types
+            if keep_top_k_fragments < n_slots:
+                in_top_k = np.zeros(n_slots, dtype=bool)
+                in_top_k[np.argsort(intensity[block])[-keep_top_k_fragments:]] = True
+                keep &= in_top_k
+        mask[block] = keep
+    return mask
+
+
+@pytest.mark.requires_numba
+@pytest.mark.parametrize(
+    "keep_top_k_fragments, min_fragment_intensity",
+    [(1000, -1), (1000, 0.5), (8, -1), (5, 0.2), (1, -1)],
+)
+def test_flatten_fragments_retains_expected_fragments(
+    keep_top_k_fragments, min_fragment_intensity
+):
+    """Only the dense slots passing the mz, intensity and top-k filters are retained."""
+    precursor_df, mz_df, intensity_df = _dense_library()
+    expected_mask = _expected_keep_mask(
+        precursor_df,
+        mz_df,
+        intensity_df,
+        keep_top_k_fragments,
+        min_fragment_intensity,
+    )
+
+    _, frag_df = flatten_fragments(
+        precursor_df,
+        mz_df,
+        intensity_df,
+        min_fragment_intensity=min_fragment_intensity,
+        keep_top_k_fragments=keep_top_k_fragments,
+    )
+
+    assert len(frag_df) == expected_mask.sum()
+    np.testing.assert_array_equal(
+        frag_df["mz"].values, mz_df.values.reshape(-1)[expected_mask]
+    )
+    np.testing.assert_array_equal(
+        frag_df["intensity"].values, intensity_df.values.reshape(-1)[expected_mask]
+    )
+
+
+@pytest.mark.requires_numba
+@pytest.mark.parametrize("keep_top_k_fragments", [1000, 5])
+def test_flatten_fragments_annotates_retained_fragments(keep_top_k_fragments):
+    """Annotation columns describe the dense slot each retained fragment came from."""
+    precursor_df, mz_df, intensity_df = _dense_library()
+    n_types = mz_df.shape[1]
+    expected_mask = _expected_keep_mask(
+        precursor_df, mz_df, intensity_df, keep_top_k_fragments, -1
+    )
+    kept_slots = np.flatnonzero(expected_mask)
+    kept_columns = kept_slots % n_types
+    kept_rows = kept_slots // n_types
+
+    _, frag_df = flatten_fragments(
+        precursor_df, mz_df, intensity_df, keep_top_k_fragments=keep_top_k_fragments
+    )
+
+    frag_types = [parse_charged_frag_type(col) for col in CHARGED_FRAG_TYPES]
+    np.testing.assert_array_equal(
+        frag_df["charge"].values,
+        np.array([charge for _, charge in frag_types])[kept_columns],
+    )
+    np.testing.assert_array_equal(
+        frag_df["type"].values,
+        np.array([FRAGMENT_TYPES[name].series_id for name, _ in frag_types])[
+            kept_columns
+        ],
+    )
+    np.testing.assert_array_equal(
+        frag_df["loss_type"].values,
+        np.array([FRAGMENT_TYPES[name].loss_id for name, _ in frag_types])[
+            kept_columns
+        ],
+    )
+
+    # position counts the fragment rows of a precursor, number counts the ion
+    # series in the direction of the fragment type
+    expected_position = kept_rows % ROWS_PER_PRECURSOR
+    np.testing.assert_array_equal(frag_df["position"].values, expected_position)
+    directions = np.array(
+        [FRAGMENT_TYPES[name].direction_id for name, _ in frag_types]
+    )[kept_columns]
+    expected_number = np.where(
+        directions == 1, expected_position + 1, ROWS_PER_PRECURSOR - expected_position
+    )
+    np.testing.assert_array_equal(frag_df["number"].values, expected_number)
+
+
+@pytest.mark.requires_numba
+@pytest.mark.parametrize("keep_top_k_fragments", [1000, 5])
+def test_flatten_fragments_reannotates_precursor_pointers(keep_top_k_fragments):
+    """The flat pointers of a precursor address exactly its retained fragments."""
+    precursor_df, mz_df, intensity_df = _dense_library()
+    n_types = mz_df.shape[1]
+    mz = mz_df.values.reshape(-1)
+    expected_mask = _expected_keep_mask(
+        precursor_df, mz_df, intensity_df, keep_top_k_fragments, -1
+    )
+
+    precursor_df, frag_df = flatten_fragments(
+        precursor_df, mz_df, intensity_df, keep_top_k_fragments=keep_top_k_fragments
+    )
+
+    for row in precursor_df.itertuples():
+        block = slice(row.frag_start_idx * n_types, row.frag_stop_idx * n_types)
+        np.testing.assert_array_equal(
+            frag_df["mz"].values[row.flat_frag_start_idx : row.flat_frag_stop_idx],
+            mz[block][expected_mask[block]],
+        )
+
+    # the pointers tile the fragment dataframe without gaps or overlaps
+    assert precursor_df.flat_frag_start_idx.iloc[0] == 0
+    assert precursor_df.flat_frag_stop_idx.iloc[-1] == len(frag_df)
+    np.testing.assert_array_equal(
+        precursor_df.flat_frag_start_idx.values[1:],
+        precursor_df.flat_frag_stop_idx.values[:-1],
+    )
+
+
+@pytest.mark.requires_numba
+def test_flatten_fragments_filters_custom_df_columns():
+    """Columns provided via custom_df are filtered like the mz column."""
+    precursor_df, mz_df, intensity_df = _dense_library()
+    cardinality_df = pd.DataFrame(
+        np.arange(mz_df.size, dtype=np.uint8).reshape(mz_df.shape),
+        columns=CHARGED_FRAG_TYPES,
+    )
+    expected_mask = _expected_keep_mask(precursor_df, mz_df, intensity_df, 5, -1)
+
+    _, frag_df = flatten_fragments(
+        precursor_df,
+        mz_df,
+        intensity_df,
+        keep_top_k_fragments=5,
+        custom_df={"cardinality": cardinality_df},
+    )
+
+    assert "cardinality" in frag_df.columns
+    np.testing.assert_array_equal(
+        frag_df["cardinality"].values,
+        cardinality_df.values.reshape(-1)[expected_mask],
+    )
+
+
+@pytest.mark.requires_numba
+def test_flatten_fragments_without_intensity():
+    """Without intensities only mz == 0 padding is removed and no intensity column is added."""
+    precursor_df, mz_df, _ = _dense_library()
+    expected_mask = _expected_keep_mask(precursor_df, mz_df, pd.DataFrame(), 1000, -1)
+
+    _, frag_df = flatten_fragments(precursor_df, mz_df, pd.DataFrame())
+
+    assert "intensity" not in frag_df.columns
+    np.testing.assert_array_equal(
+        frag_df["mz"].values, mz_df.values.reshape(-1)[expected_mask]
+    )
+
+
+@pytest.mark.requires_numba
+def test_flatten_fragments_selects_custom_columns():
+    """Only the requested annotation columns are created."""
+    precursor_df, mz_df, intensity_df = _dense_library()
+
+    _, frag_df = flatten_fragments(
+        precursor_df, mz_df, intensity_df, custom_columns=["number", "charge"]
+    )
+
+    assert list(frag_df.columns) == ["mz", "intensity", "charge", "number"]
+
+
+@pytest.mark.requires_numba
+def test_flatten_fragments_empty_precursor_df():
+    """An empty library flattens to an empty fragment dataframe."""
+    _, mz_df, intensity_df = _dense_library()
+
+    precursor_df, frag_df = flatten_fragments(
+        pd.DataFrame({"frag_start_idx": [], "frag_stop_idx": []}), mz_df, intensity_df
+    )
+
+    assert len(precursor_df) == 0
+    assert len(frag_df) == 0

--- a/tests/unit/peptide/test_fragment.py
+++ b/tests/unit/peptide/test_fragment.py
@@ -299,3 +299,29 @@ def test_flatten_fragments_empty_precursor_df():
 
     assert len(precursor_df) == 0
     assert len(frag_df) == 0
+
+
+@pytest.mark.requires_numba
+def test_flatten_fragments_long_precursor():
+    """A long precursor keeps fragment numbers above 255, and the columns stay uint32."""
+    n_rows = 260  # close to the max_frag_per_peptide limit of fill_in_indices
+    n_types = len(CHARGED_FRAG_TYPES)
+    rng = np.random.default_rng(0)
+    mz_df = pd.DataFrame(
+        (rng.random((n_rows, n_types)) * 1000 + 100).astype(PEAK_MZ_DTYPE),
+        columns=CHARGED_FRAG_TYPES,
+    )
+    intensity_df = pd.DataFrame(
+        rng.random((n_rows, n_types)).astype(PEAK_INTENSITY_DTYPE),
+        columns=CHARGED_FRAG_TYPES,
+    )
+    precursor_df = pd.DataFrame({"frag_start_idx": [0], "frag_stop_idx": [n_rows]})
+
+    _, frag_df = flatten_fragments(
+        precursor_df, mz_df, intensity_df, keep_top_k_fragments=n_rows * n_types
+    )
+
+    assert frag_df["position"].max() == n_rows - 1
+    assert frag_df["number"].max() == n_rows
+    assert frag_df["position"].dtype == np.uint32
+    assert frag_df["number"].dtype == np.uint32

--- a/tests/unit/peptide/test_fragment.py
+++ b/tests/unit/peptide/test_fragment.py
@@ -8,11 +8,11 @@ from alphabase.peptide.fragment import (
     FRAGMENT_TYPES,
     PEAK_INTENSITY_DTYPE,
     PEAK_MZ_DTYPE,
-    calculate_fragment_numbers,
+    _calculate_fragment_numbers,
+    _parse_fragment,
     filter_valid_charged_frag_types,
     flatten_fragments,
     parse_charged_frag_type,
-    parse_fragment,
 )
 
 
@@ -306,7 +306,7 @@ def test_flatten_fragments_empty_precursor_df():
 @pytest.mark.requires_numba
 def test_flatten_fragments_long_precursor():
     """A long precursor keeps fragment numbers above 255, and the columns stay uint32."""
-    n_rows = 260  # close to the max_frag_per_peptide limit of fill_in_indices
+    n_rows = 260  # close to the max_frag_per_peptide limit of _fill_in_indices
     n_types = len(CHARGED_FRAG_TYPES)
     rng = np.random.default_rng(0)
     mz_df = pd.DataFrame(
@@ -336,7 +336,7 @@ def test_calculate_fragment_numbers_counts_from_both_ends():
     row_positions = np.array([0, 0, 0, 3, 3], dtype=np.uint16)
     row_counts = np.array([7, 7, 7, 7, 7], dtype=np.uint16)
 
-    numbers = calculate_fragment_numbers(directions, row_positions, row_counts)
+    numbers = _calculate_fragment_numbers(directions, row_positions, row_counts)
 
     np.testing.assert_array_equal(numbers, [1, 7, 0, 4, 4])
     assert numbers.dtype == np.uint32
@@ -348,7 +348,7 @@ def test_parse_fragment_gives_one_value_per_fragment_row():
     frag_start_idx = np.array([0, 3], dtype=np.int64)
     frag_stop_idx = np.array([3, 7], dtype=np.int64)
 
-    row_positions, row_counts, not_top_k = parse_fragment(
+    row_positions, row_counts, not_top_k = _parse_fragment(
         frag_start_idx, frag_stop_idx, 1000, None, 7, 4
     )
 

--- a/tests/unit/peptide/test_fragment.py
+++ b/tests/unit/peptide/test_fragment.py
@@ -72,14 +72,14 @@ N_PRECURSORS = 5
 
 
 def _dense_library():
-    """Dense fragment frames with padding, and the matching precursor pointers."""
+    """Make dense fragment frames with padding, and the matching precursor pointers."""
     rng = np.random.default_rng(0)
     n_rows = N_PRECURSORS * ROWS_PER_PRECURSOR
     n_types = len(CHARGED_FRAG_TYPES)
 
     mz = (rng.random((n_rows, n_types)) * 1000 + 100).astype(PEAK_MZ_DTYPE)
-    # modloss fragments are not predicted for unmodified precursors and single
-    # fragments can fall outside the mz range: both appear as mz == 0 padding
+    # unmodified precursors have no modloss fragments, and some fragments fall
+    # outside the mz range. Both cases give mz == 0 padding.
     mz[: 2 * ROWS_PER_PRECURSOR, 4:] = 0
     mz[3, 0] = 0
     # distinct intensities make the top-k selection unambiguous
@@ -103,7 +103,7 @@ def _dense_library():
 def _expected_keep_mask(
     precursor_df, mz_df, intensity_df, keep_top_k_fragments, min_fragment_intensity
 ):
-    """Keep mask over all dense slots, derived without using flatten_fragments."""
+    """Give the keep mask over all dense slots. This does not use flatten_fragments."""
     n_types = mz_df.shape[1]
     mz = mz_df.values.reshape(-1)
     intensity = None if len(intensity_df) == 0 else intensity_df.values.reshape(-1)
@@ -131,7 +131,7 @@ def _expected_keep_mask(
 def test_flatten_fragments_retains_expected_fragments(
     keep_top_k_fragments, min_fragment_intensity
 ):
-    """Only the dense slots passing the mz, intensity and top-k filters are retained."""
+    """The flat library keeps only the slots that pass all filters."""
     precursor_df, mz_df, intensity_df = _dense_library()
     expected_mask = _expected_keep_mask(
         precursor_df,
@@ -161,7 +161,7 @@ def test_flatten_fragments_retains_expected_fragments(
 @pytest.mark.requires_numba
 @pytest.mark.parametrize("keep_top_k_fragments", [1000, 5])
 def test_flatten_fragments_annotates_retained_fragments(keep_top_k_fragments):
-    """Annotation columns describe the dense slot each retained fragment came from."""
+    """Each annotation column describes the dense slot of its fragment."""
     precursor_df, mz_df, intensity_df = _dense_library()
     n_types = mz_df.shape[1]
     expected_mask = _expected_keep_mask(
@@ -193,8 +193,8 @@ def test_flatten_fragments_annotates_retained_fragments(keep_top_k_fragments):
         ],
     )
 
-    # position counts the fragment rows of a precursor, number counts the ion
-    # series in the direction of the fragment type
+    # position counts the fragment rows of a precursor. number counts the ion
+    # series in the direction of the fragment type.
     expected_position = kept_rows % ROWS_PER_PRECURSOR
     np.testing.assert_array_equal(frag_df["position"].values, expected_position)
     directions = np.array(
@@ -209,7 +209,7 @@ def test_flatten_fragments_annotates_retained_fragments(keep_top_k_fragments):
 @pytest.mark.requires_numba
 @pytest.mark.parametrize("keep_top_k_fragments", [1000, 5])
 def test_flatten_fragments_reannotates_precursor_pointers(keep_top_k_fragments):
-    """The flat pointers of a precursor address exactly its retained fragments."""
+    """The flat pointers of a precursor address only its own fragments."""
     precursor_df, mz_df, intensity_df = _dense_library()
     n_types = mz_df.shape[1]
     mz = mz_df.values.reshape(-1)
@@ -228,7 +228,7 @@ def test_flatten_fragments_reannotates_precursor_pointers(keep_top_k_fragments):
             mz[block][expected_mask[block]],
         )
 
-    # the pointers tile the fragment dataframe without gaps or overlaps
+    # the pointers must cover the fragment dataframe with no gap and no overlap
     assert precursor_df.flat_frag_start_idx.iloc[0] == 0
     assert precursor_df.flat_frag_stop_idx.iloc[-1] == len(frag_df)
     np.testing.assert_array_equal(
@@ -239,7 +239,7 @@ def test_flatten_fragments_reannotates_precursor_pointers(keep_top_k_fragments):
 
 @pytest.mark.requires_numba
 def test_flatten_fragments_filters_custom_df_columns():
-    """Columns provided via custom_df are filtered like the mz column."""
+    """flatten_fragments filters a custom_df column like the mz column."""
     precursor_df, mz_df, intensity_df = _dense_library()
     cardinality_df = pd.DataFrame(
         np.arange(mz_df.size, dtype=np.uint8).reshape(mz_df.shape),
@@ -264,7 +264,7 @@ def test_flatten_fragments_filters_custom_df_columns():
 
 @pytest.mark.requires_numba
 def test_flatten_fragments_without_intensity():
-    """Without intensities only mz == 0 padding is removed and no intensity column is added."""
+    """Without intensities, flatten_fragments removes only the mz == 0 padding."""
     precursor_df, mz_df, _ = _dense_library()
     expected_mask = _expected_keep_mask(precursor_df, mz_df, pd.DataFrame(), 1000, -1)
 
@@ -278,7 +278,7 @@ def test_flatten_fragments_without_intensity():
 
 @pytest.mark.requires_numba
 def test_flatten_fragments_selects_custom_columns():
-    """Only the requested annotation columns are created."""
+    """flatten_fragments creates only the requested annotation columns."""
     precursor_df, mz_df, intensity_df = _dense_library()
 
     _, frag_df = flatten_fragments(
@@ -290,7 +290,7 @@ def test_flatten_fragments_selects_custom_columns():
 
 @pytest.mark.requires_numba
 def test_flatten_fragments_empty_precursor_df():
-    """An empty library flattens to an empty fragment dataframe."""
+    """An empty library gives an empty fragment dataframe."""
     _, mz_df, intensity_df = _dense_library()
 
     precursor_df, frag_df = flatten_fragments(


### PR DESCRIPTION
`flatten_fragments` allocated every flat column at dense length (`n_fragment_rows * n_fragment_types`), assembled a dataframe, then copied the kept subset out of it. Pointer reannotation added an `int64` cumulative sum over all dense slots. `parse_fragment` held the number, the position and the precursor length of every dense slot. For top-k libraries, `mz == 0` padding fills most dense slots.

- Build all columns except `mz` and `intensity` from the kept indices.
- Reannotate the pointers with `np.searchsorted` on the kept indices, instead of a dense cumulative sum.
- Accumulate the masks in place.
- Hold the number, the position and the precursor length per fragment row instead of per dense slot, because every charged fragment type of a row shares them. uint16 holds every value, which `max_frag_per_peptide` bounds.
- Compute the fragment numbers for the kept fragments only, instead of in a dense pass over every slot.
- Pass the intensities without a copy. Zeroing the intensity of padding slots was a no-op, because padding is always excluded.

Peak RSS and runtime, `keep_top_k_fragments=12`:

| dense slots | peak main | peak PR | time main | time PR |
|---|---|---|---|---|
| 120M | 6.45 GB | 1.76 GB | 7 s | 3 s |
| 480M | 23.22 GB | 6.08 GB | 15 s | 7 s |
| 1.48G | 58.73 GB | 16.08 GB | 45 s | 14 s |
