### PR TITLE
Bump python version due to biopython pin clash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alphabase"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version", "dependencies", "optional-dependencies"]
 
 authors = [


### PR DESCRIPTION
When one wishes to install this on python 3.8 which in the pyproject.toml was declared to be okay with version >=3.8 one gets error:
```
 No solution found when resolving dependencies for split (markers: python_full_version == '3.8.*'):
  ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and biopython==1.84 depends on Python>=3.9,
      we can conclude that biopython==1.84 cannot be used.
      And because alphabase[stable] depends on biopython==1.84 and your project requires alphabase[stable], we can conclude
      that your project's requirements are unsatisfiable.
```
So I bump the pyproject.toml python version to 3.9