### PR TITLE
[3/5] Refactor: extract the charged fragment type annotation and the pointer reannotation

### DIFF
--- a/alphabase/peptide/fragment.py
+++ b/alphabase/peptide/fragment.py
@@ -802,7 +802,7 @@ def mask_fragments_for_charge_greater_than_precursor_charge(
 
 
 @numba_njit(parallel=True)
-def fill_in_indices(
+def _fill_in_indices(
     frag_start_idxes: np.ndarray,
     frag_stop_idxes: np.ndarray,
     indices: np.ndarray,
@@ -877,7 +877,7 @@ def fill_in_indices(
 @numba_vectorize(
     [nb_.uint32(nb_.int8, nb_.uint32, nb_.uint32, nb_.uint32)], target="parallel"
 )
-def calculate_fragment_numbers(
+def _calculate_fragment_numbers(
     frag_direction: np.int8,
     frag_number: np.uint32,
     index: np.uint32,
@@ -907,7 +907,7 @@ def calculate_fragment_numbers(
     return frag_number
 
 
-def parse_fragment(
+def _parse_fragment(
     frag_directions: np.ndarray,
     frag_start_idxes: np.ndarray,
     frag_stop_idxes: np.ndarray,
@@ -954,7 +954,7 @@ def parse_fragment(
     )
 
     # Fill in indices, max indices and excluded indices
-    fill_in_indices(
+    _fill_in_indices(
         frag_start_idxes,
         frag_stop_idxes,
         indices,
@@ -966,7 +966,7 @@ def parse_fragment(
     )
 
     # Calculate fragment numbers
-    frag_numbers = calculate_fragment_numbers(
+    frag_numbers = _calculate_fragment_numbers(
         frag_directions, frag_numbers, indices, max_indices
     )
     return frag_numbers, indices, excluded_indices
@@ -1081,7 +1081,7 @@ def flatten_fragments(
         np.tile(frag_directions, (len(fragment_mz_df), 1)), dtype=np.int8
     )
 
-    numbers, positions, excluded_indices = parse_fragment(
+    numbers, positions, excluded_indices = _parse_fragment(
         frag_directions,
         precursor_df.frag_start_idx.values,
         precursor_df.frag_stop_idx.values,

--- a/alphabase/peptide/fragment.py
+++ b/alphabase/peptide/fragment.py
@@ -972,6 +972,76 @@ def _parse_fragment(
     return frag_numbers, indices, excluded_indices
 
 
+def _annotate_charged_frag_types(
+    charged_frag_types: np.ndarray,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Give the series id, loss id, charge and direction of every charged fragment type.
+
+    Parameters
+    ----------
+    charged_frag_types : np.ndarray
+        names of the charged fragment types, in the order of the dense columns
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+        series ids, loss ids, charges and directions, one value per charged fragment type
+
+    """
+    series_ids = []
+    loss_ids = []
+    charges = []
+    directions = []  # 'abc': direction=1, 'xyz': direction=-1, otherwise 0
+
+    for charged_frag_type in charged_frag_types:
+        frag_type, charge = parse_charged_frag_type(charged_frag_type)
+        series_ids.append(FRAGMENT_TYPES[frag_type].series_id)
+        loss_ids.append(FRAGMENT_TYPES[frag_type].loss_id)
+        charges.append(charge)
+        directions.append(FRAGMENT_TYPES[frag_type].direction_id)
+
+    return (
+        np.array(series_ids, dtype=np.int8),
+        np.array(loss_ids, dtype=np.int16),
+        np.array(charges, dtype=np.int8),
+        np.array(directions, dtype=np.int8),
+    )
+
+
+def _reannotate_precursor_pointers(
+    precursor_df: pd.DataFrame, excluded: np.ndarray, n_fragment_types: int
+) -> None:
+    """Add the flat fragment pointers to `precursor_df`, in place.
+
+    Parameters
+    ----------
+    precursor_df : pd.DataFrame
+        precursor dataframe with the `frag_start_idx` and `frag_stop_idx` columns
+
+    excluded : np.ndarray
+        whether each dense slot is excluded from the flat fragment dataframe
+
+    n_fragment_types : int
+        number of charged fragment types, that is the number of dense columns
+
+    """
+    precursor_df["flat_frag_start_idx"] = precursor_df.frag_start_idx
+    precursor_df["flat_frag_stop_idx"] = precursor_df.frag_stop_idx
+    precursor_df[["flat_frag_start_idx", "flat_frag_stop_idx"]] *= n_fragment_types
+
+    # cumulative sum counts the number of fragments before the given fragment which were removed.
+    # This sum does not include the fragment at the index position and has therefore len N +1
+    cum_sum_tresh = np.zeros(shape=len(excluded) + 1, dtype=np.int64)
+    cum_sum_tresh[1:] = np.cumsum(excluded)
+
+    precursor_df["flat_frag_start_idx"] -= cum_sum_tresh[
+        precursor_df.flat_frag_start_idx.values
+    ]
+    precursor_df["flat_frag_stop_idx"] -= cum_sum_tresh[
+        precursor_df.flat_frag_stop_idx.values
+    ]
+
+
 def flatten_fragments(
     precursor_df: pd.DataFrame,
     fragment_mz_df: pd.DataFrame,
@@ -1052,37 +1122,23 @@ def flatten_fragments(
     for col_name, df in custom_df.items():
         frag_df[col_name] = df.values.reshape(-1)
 
-    frag_types = []
-    frag_loss_types = []
-    frag_charges = []
-    frag_directions = []  # 'abc': direction=1, 'xyz': direction=-1, otherwise 0
-
-    for charged_frag_type in fragment_mz_df.columns.values:
-        frag_type, charge = parse_charged_frag_type(charged_frag_type)
-        frag_charges.append(charge)
-        frag_types.append(FRAGMENT_TYPES[frag_type].series_id)
-        frag_loss_types.append(FRAGMENT_TYPES[frag_type].loss_id)
-        frag_directions.append(FRAGMENT_TYPES[frag_type].direction_id)
-
-    if "type" in custom_columns:
-        frag_df["type"] = np.array(
-            np.tile(frag_types, len(fragment_mz_df)), dtype=np.int8
-        )
-    if "loss_type" in custom_columns:
-        frag_df["loss_type"] = np.array(
-            np.tile(frag_loss_types, len(fragment_mz_df)), dtype=np.int16
-        )
-    if "charge" in custom_columns:
-        frag_df["charge"] = np.array(
-            np.tile(frag_charges, len(fragment_mz_df)), dtype=np.int8
-        )
-
-    frag_directions = np.array(
-        np.tile(frag_directions, (len(fragment_mz_df), 1)), dtype=np.int8
+    series_ids, loss_ids, charges, directions = _annotate_charged_frag_types(
+        fragment_mz_df.columns.values
     )
 
+    # tiling the typed arrays keeps their dtype. A tiled list of Python ints gave
+    # a dense int64 array first, which cost 8 bytes per dense slot.
+    if "type" in custom_columns:
+        frag_df["type"] = np.tile(series_ids, len(fragment_mz_df))
+    if "loss_type" in custom_columns:
+        frag_df["loss_type"] = np.tile(loss_ids, len(fragment_mz_df))
+    if "charge" in custom_columns:
+        frag_df["charge"] = np.tile(charges, len(fragment_mz_df))
+
+    dense_directions = np.tile(directions, (len(fragment_mz_df), 1))
+
     numbers, positions, excluded_indices = _parse_fragment(
-        frag_directions,
+        dense_directions,
         precursor_df.frag_start_idx.values,
         precursor_df.frag_stop_idx.values,
         keep_top_k_fragments,
@@ -1095,12 +1151,6 @@ def flatten_fragments(
 
     if "position" in custom_columns:
         frag_df["position"] = positions.reshape(-1)
-
-    precursor_df["flat_frag_start_idx"] = precursor_df.frag_start_idx
-    precursor_df["flat_frag_stop_idx"] = precursor_df.frag_stop_idx
-    precursor_df[["flat_frag_start_idx", "flat_frag_stop_idx"]] *= len(
-        fragment_mz_df.columns
-    )
 
     if use_intensity:
         frag_df["intensity"][frag_df["mz"] == 0.0] = 0.0
@@ -1117,17 +1167,7 @@ def flatten_fragments(
     frag_df = frag_df[~excluded]
     frag_df = frag_df.reset_index(drop=True)
 
-    # cumulative sum counts the number of fragments before the given fragment which were removed.
-    # This sum does not include the fragment at the index position and has therefore len N +1
-    cum_sum_tresh = np.zeros(shape=len(excluded) + 1, dtype=np.int64)
-    cum_sum_tresh[1:] = np.cumsum(excluded)
-
-    precursor_df["flat_frag_start_idx"] -= cum_sum_tresh[
-        precursor_df.flat_frag_start_idx.values
-    ]
-    precursor_df["flat_frag_stop_idx"] -= cum_sum_tresh[
-        precursor_df.flat_frag_stop_idx.values
-    ]
+    _reannotate_precursor_pointers(precursor_df, excluded, len(fragment_mz_df.columns))
 
     return precursor_df, frag_df
 

--- a/tests/unit/peptide/test_fragment.py
+++ b/tests/unit/peptide/test_fragment.py
@@ -1,9 +1,15 @@
 from unittest.mock import patch
 
+import numpy as np
+import pandas as pd
 import pytest
 
 from alphabase.peptide.fragment import (
+    FRAGMENT_TYPES,
+    PEAK_INTENSITY_DTYPE,
+    PEAK_MZ_DTYPE,
     filter_valid_charged_frag_types,
+    flatten_fragments,
     parse_charged_frag_type,
 )
 
@@ -51,3 +57,271 @@ def test_filter_valid_charged_frag_types(mock_parse):
         )
     assert result == ["b_z1", "y_z2"]
     assert len(recorded_warnings) == 1  # Should have 2 warning messages
+
+
+CHARGED_FRAG_TYPES = [
+    "b_z1",
+    "b_z2",
+    "y_z1",
+    "y_z2",
+    "b_modloss_z1",
+    "y_modloss_z1",
+]
+ROWS_PER_PRECURSOR = 4
+N_PRECURSORS = 5
+
+
+def _dense_library():
+    """Make dense fragment frames with padding, and the matching precursor pointers."""
+    rng = np.random.default_rng(0)
+    n_rows = N_PRECURSORS * ROWS_PER_PRECURSOR
+    n_types = len(CHARGED_FRAG_TYPES)
+
+    mz = (rng.random((n_rows, n_types)) * 1000 + 100).astype(PEAK_MZ_DTYPE)
+    # unmodified precursors have no modloss fragments, and some fragments fall
+    # outside the mz range. Both cases give mz == 0 padding.
+    mz[: 2 * ROWS_PER_PRECURSOR, 4:] = 0
+    mz[3, 0] = 0
+    # distinct intensities make the top-k selection unambiguous
+    intensity = rng.permutation(n_rows * n_types).reshape(n_rows, n_types)
+    intensity = (intensity / intensity.max()).astype(PEAK_INTENSITY_DTYPE)
+
+    frag_start_idx = np.arange(N_PRECURSORS) * ROWS_PER_PRECURSOR
+    precursor_df = pd.DataFrame(
+        {
+            "frag_start_idx": frag_start_idx,
+            "frag_stop_idx": frag_start_idx + ROWS_PER_PRECURSOR,
+        }
+    )
+    return (
+        precursor_df,
+        pd.DataFrame(mz, columns=CHARGED_FRAG_TYPES),
+        pd.DataFrame(intensity, columns=CHARGED_FRAG_TYPES),
+    )
+
+
+def _expected_keep_mask(
+    precursor_df, mz_df, intensity_df, keep_top_k_fragments, min_fragment_intensity
+):
+    """Give the keep mask over all dense slots. This does not use flatten_fragments."""
+    n_types = mz_df.shape[1]
+    mz = mz_df.values.reshape(-1)
+    intensity = None if len(intensity_df) == 0 else intensity_df.values.reshape(-1)
+
+    mask = np.zeros(mz.size, dtype=bool)
+    for start, stop in zip(precursor_df.frag_start_idx, precursor_df.frag_stop_idx):
+        block = slice(start * n_types, stop * n_types)
+        keep = mz[block] != 0
+        if intensity is not None:
+            keep &= intensity[block] >= min_fragment_intensity
+            n_slots = (stop - start) * n_types
+            if keep_top_k_fragments < n_slots:
+                in_top_k = np.zeros(n_slots, dtype=bool)
+                in_top_k[np.argsort(intensity[block])[-keep_top_k_fragments:]] = True
+                keep &= in_top_k
+        mask[block] = keep
+    return mask
+
+
+@pytest.mark.requires_numba
+@pytest.mark.parametrize(
+    "keep_top_k_fragments, min_fragment_intensity",
+    [(1000, -1), (1000, 0.5), (8, -1), (5, 0.2), (1, -1)],
+)
+def test_flatten_fragments_retains_expected_fragments(
+    keep_top_k_fragments, min_fragment_intensity
+):
+    """The flat library keeps only the slots that pass all filters."""
+    precursor_df, mz_df, intensity_df = _dense_library()
+    expected_mask = _expected_keep_mask(
+        precursor_df,
+        mz_df,
+        intensity_df,
+        keep_top_k_fragments,
+        min_fragment_intensity,
+    )
+
+    _, frag_df = flatten_fragments(
+        precursor_df,
+        mz_df,
+        intensity_df,
+        min_fragment_intensity=min_fragment_intensity,
+        keep_top_k_fragments=keep_top_k_fragments,
+    )
+
+    assert len(frag_df) == expected_mask.sum()
+    np.testing.assert_array_equal(
+        frag_df["mz"].values, mz_df.values.reshape(-1)[expected_mask]
+    )
+    np.testing.assert_array_equal(
+        frag_df["intensity"].values, intensity_df.values.reshape(-1)[expected_mask]
+    )
+
+
+@pytest.mark.requires_numba
+@pytest.mark.parametrize("keep_top_k_fragments", [1000, 5])
+def test_flatten_fragments_annotates_retained_fragments(keep_top_k_fragments):
+    """Each annotation column describes the dense slot of its fragment."""
+    precursor_df, mz_df, intensity_df = _dense_library()
+    n_types = mz_df.shape[1]
+    expected_mask = _expected_keep_mask(
+        precursor_df, mz_df, intensity_df, keep_top_k_fragments, -1
+    )
+    kept_slots = np.flatnonzero(expected_mask)
+    kept_columns = kept_slots % n_types
+    kept_rows = kept_slots // n_types
+
+    _, frag_df = flatten_fragments(
+        precursor_df, mz_df, intensity_df, keep_top_k_fragments=keep_top_k_fragments
+    )
+
+    frag_types = [parse_charged_frag_type(col) for col in CHARGED_FRAG_TYPES]
+    np.testing.assert_array_equal(
+        frag_df["charge"].values,
+        np.array([charge for _, charge in frag_types])[kept_columns],
+    )
+    np.testing.assert_array_equal(
+        frag_df["type"].values,
+        np.array([FRAGMENT_TYPES[name].series_id for name, _ in frag_types])[
+            kept_columns
+        ],
+    )
+    np.testing.assert_array_equal(
+        frag_df["loss_type"].values,
+        np.array([FRAGMENT_TYPES[name].loss_id for name, _ in frag_types])[
+            kept_columns
+        ],
+    )
+
+    # position counts the fragment rows of a precursor. number counts the ion
+    # series in the direction of the fragment type.
+    expected_position = kept_rows % ROWS_PER_PRECURSOR
+    np.testing.assert_array_equal(frag_df["position"].values, expected_position)
+    directions = np.array(
+        [FRAGMENT_TYPES[name].direction_id for name, _ in frag_types]
+    )[kept_columns]
+    expected_number = np.where(
+        directions == 1, expected_position + 1, ROWS_PER_PRECURSOR - expected_position
+    )
+    np.testing.assert_array_equal(frag_df["number"].values, expected_number)
+
+
+@pytest.mark.requires_numba
+@pytest.mark.parametrize("keep_top_k_fragments", [1000, 5])
+def test_flatten_fragments_reannotates_precursor_pointers(keep_top_k_fragments):
+    """The flat pointers of a precursor address only its own fragments."""
+    precursor_df, mz_df, intensity_df = _dense_library()
+    n_types = mz_df.shape[1]
+    mz = mz_df.values.reshape(-1)
+    expected_mask = _expected_keep_mask(
+        precursor_df, mz_df, intensity_df, keep_top_k_fragments, -1
+    )
+
+    precursor_df, frag_df = flatten_fragments(
+        precursor_df, mz_df, intensity_df, keep_top_k_fragments=keep_top_k_fragments
+    )
+
+    for row in precursor_df.itertuples():
+        block = slice(row.frag_start_idx * n_types, row.frag_stop_idx * n_types)
+        np.testing.assert_array_equal(
+            frag_df["mz"].values[row.flat_frag_start_idx : row.flat_frag_stop_idx],
+            mz[block][expected_mask[block]],
+        )
+
+    # the pointers must cover the fragment dataframe with no gap and no overlap
+    assert precursor_df.flat_frag_start_idx.iloc[0] == 0
+    assert precursor_df.flat_frag_stop_idx.iloc[-1] == len(frag_df)
+    np.testing.assert_array_equal(
+        precursor_df.flat_frag_start_idx.values[1:],
+        precursor_df.flat_frag_stop_idx.values[:-1],
+    )
+
+
+@pytest.mark.requires_numba
+def test_flatten_fragments_filters_custom_df_columns():
+    """flatten_fragments filters a custom_df column like the mz column."""
+    precursor_df, mz_df, intensity_df = _dense_library()
+    cardinality_df = pd.DataFrame(
+        np.arange(mz_df.size, dtype=np.uint8).reshape(mz_df.shape),
+        columns=CHARGED_FRAG_TYPES,
+    )
+    expected_mask = _expected_keep_mask(precursor_df, mz_df, intensity_df, 5, -1)
+
+    _, frag_df = flatten_fragments(
+        precursor_df,
+        mz_df,
+        intensity_df,
+        keep_top_k_fragments=5,
+        custom_df={"cardinality": cardinality_df},
+    )
+
+    assert "cardinality" in frag_df.columns
+    np.testing.assert_array_equal(
+        frag_df["cardinality"].values,
+        cardinality_df.values.reshape(-1)[expected_mask],
+    )
+
+
+@pytest.mark.requires_numba
+def test_flatten_fragments_without_intensity():
+    """Without intensities, flatten_fragments removes only the mz == 0 padding."""
+    precursor_df, mz_df, _ = _dense_library()
+    expected_mask = _expected_keep_mask(precursor_df, mz_df, pd.DataFrame(), 1000, -1)
+
+    _, frag_df = flatten_fragments(precursor_df, mz_df, pd.DataFrame())
+
+    assert "intensity" not in frag_df.columns
+    np.testing.assert_array_equal(
+        frag_df["mz"].values, mz_df.values.reshape(-1)[expected_mask]
+    )
+
+
+@pytest.mark.requires_numba
+def test_flatten_fragments_selects_custom_columns():
+    """flatten_fragments creates only the requested annotation columns."""
+    precursor_df, mz_df, intensity_df = _dense_library()
+
+    _, frag_df = flatten_fragments(
+        precursor_df, mz_df, intensity_df, custom_columns=["number", "charge"]
+    )
+
+    assert list(frag_df.columns) == ["mz", "intensity", "charge", "number"]
+
+
+@pytest.mark.requires_numba
+def test_flatten_fragments_empty_precursor_df():
+    """An empty library gives an empty fragment dataframe."""
+    _, mz_df, intensity_df = _dense_library()
+
+    precursor_df, frag_df = flatten_fragments(
+        pd.DataFrame({"frag_start_idx": [], "frag_stop_idx": []}), mz_df, intensity_df
+    )
+
+    assert len(precursor_df) == 0
+    assert len(frag_df) == 0
+
+
+@pytest.mark.requires_numba
+def test_flatten_fragments_long_precursor():
+    """A long precursor keeps fragment numbers above 255, and the columns stay uint32."""
+    n_rows = 260  # close to the max_frag_per_peptide limit of _fill_in_indices
+    n_types = len(CHARGED_FRAG_TYPES)
+    rng = np.random.default_rng(0)
+    mz_df = pd.DataFrame(
+        (rng.random((n_rows, n_types)) * 1000 + 100).astype(PEAK_MZ_DTYPE),
+        columns=CHARGED_FRAG_TYPES,
+    )
+    intensity_df = pd.DataFrame(
+        rng.random((n_rows, n_types)).astype(PEAK_INTENSITY_DTYPE),
+        columns=CHARGED_FRAG_TYPES,
+    )
+    precursor_df = pd.DataFrame({"frag_start_idx": [0], "frag_stop_idx": [n_rows]})
+
+    _, frag_df = flatten_fragments(
+        precursor_df, mz_df, intensity_df, keep_top_k_fragments=n_rows * n_types
+    )
+
+    assert frag_df["position"].max() == n_rows - 1
+    assert frag_df["number"].max() == n_rows
+    assert frag_df["position"].dtype == np.uint32
+    assert frag_df["number"].dtype == np.uint32


### PR DESCRIPTION
**Pure refactor. No functional change, output bit-identical to main.**

Move two concerns out of the body of `flatten_fragments`, so the memory changes that follow are diffs in named helpers instead of a long function body.

- Return the series id, loss id, charge and direction as typed arrays instead of four parallel lists of Python ints. Tiling a typed array keeps its dtype, so the dense type/loss_type/charge/direction arrays no longer pass through an `int64` intermediate of 8 bytes per dense slot.

Stacked on #435. Splitting #429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)