### PR TITLE
Abandon py 38

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,19 +8,21 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.0
-  hooks:
-    - id: ruff-format
-    # running ruff with rules in pyproject.toml (all files, limited rules)
-    - id: ruff
-      args:
-        - "--fix"
-- repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.7.3 # newer version -> stricter
   hooks:
     - id: ruff
-      # running ruff again with rules in ruff-lint-psm-readers.toml (specific files, all rules)
+      name: ruff (permissive)
+      # running ruff with rules in ruff-lint-psm-readers.toml (specific files, all rules)
       args:
         - "--config"
         - "ruff-lint-psm-readers.toml"
         - "--fix"
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.4.0
+  hooks:
+    # running ruff with rules in pyproject.toml (all files, limited rules)
+    - id: ruff
+      name: ruff (strict)
+      args:
+        - "--fix"
+    - id: ruff-format

--- a/alphabase/constants/aa.py
+++ b/alphabase/constants/aa.py
@@ -1,5 +1,4 @@
 import os
-import typing
 
 import numpy as np
 import pandas as pd
@@ -29,7 +28,7 @@ AA_DF: pd.DataFrame = pd.DataFrame()
 AA_Composition: dict = {}
 
 
-def replace_atoms(atom_replace_dict: typing.Dict):
+def replace_atoms(atom_replace_dict: dict):
     for aa, row in aa_formula.iterrows():
         formula = row["formula"]
         atom_comp = dict(parse_formula(formula))
@@ -81,7 +80,7 @@ def reset_AA_Composition():
 reset_AA_Composition()
 
 
-def reset_AA_atoms(atom_replace_dict: typing.Dict = {}):
+def reset_AA_atoms(atom_replace_dict: dict = {}):
     reset_elements()
     replace_atoms(atom_replace_dict)
     reset_AA_mass()

--- a/alphabase/constants/atom.py
+++ b/alphabase/constants/atom.py
@@ -1,6 +1,5 @@
 import os
 import re
-import typing
 from collections import defaultdict
 
 import numpy as np
@@ -102,7 +101,7 @@ MASS_H2O: int = None  # raise errors if the value is not reset
 MASS_NH3: int = None
 
 
-def update_atom_infos(new_atom_info: typing.Dict):
+def update_atom_infos(new_atom_info: dict):
     """Update the atom information in CHEM_INFO_DICT.
 
     Args:

--- a/alphabase/constants/isotope.py
+++ b/alphabase/constants/isotope.py
@@ -19,7 +19,7 @@ def abundance_convolution(
     mono1: int,
     d2: np.ndarray,
     mono2: int,
-) -> typing.Tuple[np.ndarray, int]:
+) -> tuple[np.ndarray, int]:
     """
     If we have two isotope distributions,
     we can convolute them into one distribution.
@@ -60,7 +60,7 @@ def one_element_dist(
     n: int,
     chem_isotope_dist: NumbaTypedDict,
     chem_mono_idx: NumbaTypedDict,
-) -> typing.Tuple[np.ndarray, int]:
+) -> tuple[np.ndarray, int]:
     """
     Calculate the isotope distribution for
     an element and its numbers.
@@ -101,7 +101,7 @@ def one_element_dist(
         )
 
 
-def formula_dist(formula: typing.Union[list, str]) -> typing.Tuple[np.ndarray, int]:
+def formula_dist(formula: typing.Union[list, str]) -> tuple[np.ndarray, int]:
     """
     Generate the isotope distribution and the mono index for
     a given formula (as a list, e.g. `[('H', 2), ('C', 2), ('O', 1)]`).
@@ -210,8 +210,8 @@ class IsotopeDistribution:
 
     def calc_formula_distribution(
         self,
-        formula: typing.List[typing.Tuple[str, int]],
-    ) -> typing.Tuple[np.ndarray, int]:
+        formula: list[tuple[str, int]],
+    ) -> tuple[np.ndarray, int]:
         """Calculate isotope abundance distribution for a given formula
 
         Parameters

--- a/alphabase/constants/modification.py
+++ b/alphabase/constants/modification.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Union
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -184,7 +184,7 @@ load_mod_df()
 
 
 def calc_modification_mass(
-    nAA: int, mod_names: List[str], mod_sites: List[int]
+    nAA: int, mod_names: list[str], mod_sites: list[int]
 ) -> np.ndarray:
     """
     Calculate modification masses for the given peptide length (`nAA`),
@@ -221,7 +221,7 @@ def calc_modification_mass(
 
 
 def calc_mod_masses_for_same_len_seqs(
-    nAA: int, mod_names_list: List[List[str]], mod_sites_list: List[List[int]]
+    nAA: int, mod_names_list: list[list[str]], mod_sites_list: list[list[int]]
 ) -> np.ndarray:
     """
     Calculate modification masses for the given peptides with same peptide length (`nAA`).
@@ -258,7 +258,7 @@ def calc_mod_masses_for_same_len_seqs(
     return masses
 
 
-def calc_modification_mass_sum(mod_names: List[str]) -> float:
+def calc_modification_mass_sum(mod_names: list[str]) -> float:
     """
     Calculate summed mass of the given modification
     without knowing the sites and peptide length.
@@ -314,8 +314,8 @@ def _calc_modloss_with_importance(
 
 def calc_modloss_mass_with_importance(
     nAA: int,
-    mod_names: List,
-    mod_sites: List,
+    mod_names: list,
+    mod_sites: list,
     for_nterm_frag: bool,
 ) -> np.ndarray:
     """
@@ -390,8 +390,8 @@ def _calc_modloss(mod_losses: np.ndarray) -> np.ndarray:
 
 def calc_modloss_mass(
     nAA: int,
-    mod_names: List,
-    mod_sites: List,
+    mod_names: list,
+    mod_sites: list,
     for_nterm_frag: bool,
 ) -> np.ndarray:
     """

--- a/alphabase/peptide/fragment.py
+++ b/alphabase/peptide/fragment.py
@@ -1,6 +1,6 @@
 import warnings
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple, Union
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -316,7 +316,7 @@ def parse_all_frag_type_representation():
 parse_all_frag_type_representation()
 
 
-def sort_charged_frag_types(charged_frag_types: List[str]) -> List[str]:
+def sort_charged_frag_types(charged_frag_types: list[str]) -> list[str]:
     """charged frag types are sorted by (no-loss, loss) and then alphabetically"""
     has_loss = [
         f.replace(FRAGMENT_CHARGE_SEPARATOR, "").count("_") > 0
@@ -328,8 +328,8 @@ def sort_charged_frag_types(charged_frag_types: List[str]) -> List[str]:
 
 
 def get_charged_frag_types(
-    frag_types: List[str], max_frag_charge: int = 2
-) -> List[str]:
+    frag_types: list[str], max_frag_charge: int = 2
+) -> list[str]:
     """
     Calculate the combination of fragment types and charge states.
     Returns a sorted list of charged fragment types.
@@ -364,8 +364,8 @@ def get_charged_frag_types(
 
 
 def filter_valid_charged_frag_types(
-    charged_frag_types: List[str],
-) -> List[str]:
+    charged_frag_types: list[str],
+) -> list[str]:
     """
     Filters a list of charged fragment types and returns only the valid ones.
     A valid charged fragment type must:
@@ -397,7 +397,7 @@ def filter_valid_charged_frag_types(
     return valid_types
 
 
-def parse_charged_frag_type(charged_frag_type: str) -> Tuple[str, int]:
+def parse_charged_frag_type(charged_frag_type: str) -> tuple[str, int]:
     """
     Oppsite to `get_charged_frag_types`.
 
@@ -440,8 +440,8 @@ def parse_charged_frag_type(charged_frag_type: str) -> Tuple[str, int]:
 
 
 def init_zero_fragment_dataframe(
-    peplen_array: np.ndarray, charged_frag_types: List[str], dtype=PEAK_MZ_DTYPE
-) -> Tuple[pd.DataFrame, np.ndarray, np.ndarray]:
+    peplen_array: np.ndarray, charged_frag_types: list[str], dtype=PEAK_MZ_DTYPE
+) -> tuple[pd.DataFrame, np.ndarray, np.ndarray]:
     """Initialize a zero dataframe based on peptide length
     (nAA) array (peplen_array) and charge_frag_types (column number).
     The row number of returned dataframe is np.sum(peplen_array-1).
@@ -487,7 +487,7 @@ def init_fragment_dataframe_from_other(
 
 def init_fragment_by_precursor_dataframe(
     precursor_df,
-    charged_frag_types: List[str],
+    charged_frag_types: list[str],
     *,
     reference_fragment_df: pd.DataFrame = None,
     dtype: np.dtype = PEAK_MZ_DTYPE,
@@ -572,8 +572,8 @@ def update_sliced_fragment_dataframe(
     fragment_df: pd.DataFrame,
     fragment_df_vals: np.ndarray,
     values: np.ndarray,
-    frag_start_end_list: List[Tuple[int, int]],
-    charged_frag_types: List[str] = None,
+    frag_start_end_list: list[tuple[int, int]],
+    charged_frag_types: list[str] = None,
 ):
     """
     Set the values of the slices `frag_start_end_list=[(start,end),(start,end),...]`
@@ -616,8 +616,8 @@ def update_sliced_fragment_dataframe(
 
 def get_sliced_fragment_dataframe(
     fragment_df: pd.DataFrame,
-    frag_start_end_list: Union[List, np.ndarray],
-    charged_frag_types: List = None,
+    frag_start_end_list: Union[list, np.ndarray],
+    charged_frag_types: list = None,
 ) -> pd.DataFrame:
     """
     Get the sliced fragment_df from `frag_start_end_list=[(start,end),(start,end),...]`.
@@ -653,10 +653,10 @@ def get_sliced_fragment_dataframe(
 
 
 def concat_precursor_fragment_dataframes(
-    precursor_df_list: List[pd.DataFrame],
-    fragment_df_list: List[pd.DataFrame],
+    precursor_df_list: list[pd.DataFrame],
+    fragment_df_list: list[pd.DataFrame],
     *other_fragment_df_lists,
-) -> Tuple[pd.DataFrame, ...]:
+) -> tuple[pd.DataFrame, ...]:
     """
     Since fragment_df is indexed by precursor_df, when we concatenate multiple
     fragment_df, the indexed positions will change for in precursor_dfs,
@@ -914,7 +914,7 @@ def parse_fragment(
     top_k: int,
     intensities: np.ndarray,
     number_of_fragment_types: int,
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Parse fragments to get fragment numbers, fragment positions and not top k excluded indices in one hit
     faster than doing each operation individually, and makes the most of the operations that are done in parallel.
@@ -979,8 +979,8 @@ def flatten_fragments(
     min_fragment_intensity: float = -1,
     keep_top_k_fragments: int = 1000,
     custom_columns: list = ["type", "number", "position", "charge", "loss_type"],
-    custom_df: Dict[str, pd.DataFrame] = {},
-) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    custom_df: dict[str, pd.DataFrame] = {},
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     """
     Converts the tabular fragment format consisting of
     the `fragment_mz_df` and the `fragment_intensity_df`
@@ -1168,10 +1168,10 @@ def compress_fragment_indices(frag_idx):
 
 def remove_unused_fragments(
     precursor_df: pd.DataFrame,
-    fragment_df_list: Tuple[pd.DataFrame, ...],
+    fragment_df_list: tuple[pd.DataFrame, ...],
     frag_start_col: str = "frag_start_idx",
     frag_stop_col: str = "frag_stop_idx",
-) -> Tuple[pd.DataFrame, Tuple[pd.DataFrame, ...]]:
+) -> tuple[pd.DataFrame, tuple[pd.DataFrame, ...]]:
     """Removes unused fragments of removed precursors,
     reannotates the `frag_start_col` and `frag_stop_col`
 
@@ -1220,7 +1220,7 @@ def remove_unused_fragments(
 
 def create_fragment_mz_dataframe_by_sort_precursor(
     precursor_df: pd.DataFrame,
-    charged_frag_types: List,
+    charged_frag_types: list,
     batch_size: int = 500000,
     dtype: np.dtype = PEAK_MZ_DTYPE,
 ) -> pd.DataFrame:
@@ -1277,7 +1277,7 @@ def create_fragment_mz_dataframe_by_sort_precursor(
 
 def create_fragment_mz_dataframe(
     precursor_df: pd.DataFrame,
-    charged_frag_types: List,
+    charged_frag_types: list,
     *,
     reference_fragment_df: pd.DataFrame = None,
     inplace_in_reference: bool = False,

--- a/alphabase/peptide/mass_calc.py
+++ b/alphabase/peptide/mass_calc.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 
 from alphabase.constants.aa import (

--- a/alphabase/peptide/mass_calc.py
+++ b/alphabase/peptide/mass_calc.py
@@ -1,4 +1,3 @@
-from typing import List, Tuple
 
 import numpy as np
 
@@ -17,7 +16,7 @@ from alphabase.constants.modification import (
 
 
 def calc_diff_modification_mass(
-    pep_len: int, mass_diffs: List[float], mass_diff_sites: List[int]
+    pep_len: int, mass_diffs: list[float], mass_diff_sites: list[int]
 ) -> np.ndarray:
     """
     For open-search, we may also get modification
@@ -52,7 +51,7 @@ def calc_diff_modification_mass(
 
 
 def calc_mod_diff_masses_for_same_len_seqs(
-    nAA: int, aa_mass_diffs_list: List[List[float]], mod_sites_list: List[List[int]]
+    nAA: int, aa_mass_diffs_list: list[list[float]], mod_sites_list: list[list[int]]
 ) -> np.ndarray:
     """
     Calculate diff modification masses for the given peptide length (`nAA`),
@@ -96,11 +95,11 @@ def calc_mod_diff_masses_for_same_len_seqs(
 
 def calc_b_y_and_peptide_mass(
     sequence: str,
-    mod_names: List[str],
-    mod_sites: List[int],
-    aa_mass_diffs: List[float] = None,
-    aa_mass_diff_sites: List[int] = None,
-) -> Tuple[np.ndarray, np.ndarray, float]:
+    mod_names: list[str],
+    mod_sites: list[int],
+    aa_mass_diffs: list[float] = None,
+    aa_mass_diff_sites: list[int] = None,
+) -> tuple[np.ndarray, np.ndarray, float]:
     """
     It is highly recommend to use
     `calc_b_y_and_peptide_masses_for_same_len_seqs`
@@ -124,7 +123,7 @@ def calc_b_y_and_peptide_mass(
 
 
 def calc_peptide_masses_for_same_len_seqs(
-    sequences: np.ndarray, mod_list: List[str], mod_diff_list: List[str] = None
+    sequences: np.ndarray, mod_list: list[str], mod_diff_list: list[str] = None
 ) -> np.ndarray:
     """
     Calculate peptide masses for peptide sequences with same lengths.
@@ -171,11 +170,11 @@ def calc_peptide_masses_for_same_len_seqs(
 
 def calc_b_y_and_peptide_masses_for_same_len_seqs(
     sequences: np.ndarray,
-    mod_list: List[List[str]],
-    site_list: List[List[int]],
-    mod_diff_list: List[List[float]] = None,
-    mod_diff_site_list: List[List[int]] = None,
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    mod_list: list[list[str]],
+    site_list: list[list[int]],
+    mod_diff_list: list[list[float]] = None,
+    mod_diff_site_list: list[list[int]] = None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Calculate b/y fragment masses and peptide masses
     for peptide sequences with same lengths.

--- a/alphabase/pg_reader/pg_reader.py
+++ b/alphabase/pg_reader/pg_reader.py
@@ -2,9 +2,10 @@
 
 import re
 import warnings
+from collections.abc import Iterable
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional, Type, Union
+from typing import Any, Dict, Optional, Type, Union
 
 import pandas as pd
 

--- a/alphabase/pg_reader/pg_reader.py
+++ b/alphabase/pg_reader/pg_reader.py
@@ -5,7 +5,7 @@ import warnings
 from collections.abc import Iterable
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, Optional, Type, Union
+from typing import Any, Optional, Union
 
 import pandas as pd
 
@@ -94,7 +94,7 @@ class PGReaderBase:
 
         self.measurement_regex = self._get_measurement_regex(regex=measurement_regex)
 
-    def add_column_mapping(self, column_mapping: Dict) -> None:
+    def add_column_mapping(self, column_mapping: dict) -> None:
         """Add additional column mappings for the search engine."""
         self.column_mapping = {**self.column_mapping, **column_mapping}
 
@@ -274,10 +274,10 @@ class PGReaderProvider:
 
     def __init__(self):
         """Initialize PGReaderProvider."""
-        self.reader_dict: dict[str, Type[PGReaderBase]] = {}
+        self.reader_dict: dict[str, type[PGReaderBase]] = {}
 
     def register_reader(
-        self, reader_type: str, reader_class: Type[PGReaderBase]
+        self, reader_type: str, reader_class: type[PGReaderBase]
     ) -> None:
         """Register a reader by reader_type."""
         self.reader_dict[reader_type.lower()] = reader_class

--- a/alphabase/psm_reader/alphapept_reader.py
+++ b/alphabase/psm_reader/alphapept_reader.py
@@ -1,7 +1,6 @@
 """Reader for AlphaPept's .ms_data.hdf files."""
 
 from pathlib import Path
-from typing import Tuple
 
 import h5py
 import numpy as np
@@ -17,7 +16,7 @@ from alphabase.psm_reader.psm_reader import (
 _SEPARATOR = ModificationKeys.SEPARATOR
 
 
-def parse_ap(precursor: str) -> Tuple[str, str, str, str, int]:
+def parse_ap(precursor: str) -> tuple[str, str, str, str, int]:
     """Parser to parse peptide strings."""
     items = precursor.split("_")
     decoy = 1 if len(items) == 3 else 0  # noqa: PLR2004 magic value

--- a/alphabase/psm_reader/dia_psm_reader.py
+++ b/alphabase/psm_reader/dia_psm_reader.py
@@ -1,6 +1,6 @@
 """Readers for Spectronaut's output library and reports, Swath data and DIANN data."""
 
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -49,7 +49,7 @@ class DiannReader(ModifiedSequenceReader):
         *,
         column_mapping: Optional[dict] = None,
         modification_mapping: Optional[dict] = None,
-        mod_seq_columns: Optional[List[str]] = None,
+        mod_seq_columns: Optional[list[str]] = None,
         fdr: float = 0.01,
         keep_decoy: bool = False,
         rt_unit: Optional[str] = None,

--- a/alphabase/psm_reader/keys.py
+++ b/alphabase/psm_reader/keys.py
@@ -1,6 +1,6 @@
 """Constants for accessing the columns of a PSM dataframe."""
 
-from typing import Any, List, NoReturn
+from typing import Any, NoReturn
 
 
 class ConstantsClass(type):
@@ -10,7 +10,7 @@ class ConstantsClass(type):
         """Raise an error when trying to set an attribute."""
         raise TypeError("Constants class cannot be modified")
 
-    def get_values(cls) -> List[str]:
+    def get_values(cls) -> list[str]:
         """Get all user-defined string values of the class."""
         return [
             value

--- a/alphabase/psm_reader/maxquant_reader.py
+++ b/alphabase/psm_reader/maxquant_reader.py
@@ -2,7 +2,7 @@
 
 import warnings
 from abc import ABC
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -134,7 +134,7 @@ class ModifiedSequenceReader(PSMReaderBase, ABC):
         *,
         column_mapping: Optional[dict] = None,
         modification_mapping: Optional[dict] = None,
-        mod_seq_columns: Optional[List[str]] = None,
+        mod_seq_columns: Optional[list[str]] = None,
         fdr: float = 0.01,
         keep_decoy: bool = False,
         rt_unit: Optional[str] = None,
@@ -198,7 +198,7 @@ class MaxQuantReader(ModifiedSequenceReader):
         *,
         column_mapping: Optional[dict] = None,
         modification_mapping: Optional[dict] = None,
-        mod_seq_columns: Optional[List[str]] = None,
+        mod_seq_columns: Optional[list[str]] = None,
         fdr: float = 0.01,
         keep_decoy: bool = False,
         rt_unit: Optional[str] = None,

--- a/alphabase/psm_reader/modification_mapper.py
+++ b/alphabase/psm_reader/modification_mapper.py
@@ -2,7 +2,7 @@
 
 import copy
 from collections import defaultdict
-from typing import Dict, Optional
+from typing import Optional
 
 from alphabase.constants.modification import ModificationKeys
 from alphabase.psm_reader.utils import MOD_TO_UNIMOD_DICT, get_extended_modifications
@@ -13,9 +13,9 @@ class ModificationMapper:
 
     def __init__(
         self,
-        custom_modification_mapping: Optional[Dict[str, str]],
+        custom_modification_mapping: Optional[dict[str, str]],
         *,
-        reader_yaml: Dict,
+        reader_yaml: dict,
         mapping_type: str,
         add_unimod_to_mod_mapping: bool,
     ):
@@ -87,7 +87,7 @@ class ModificationMapper:
             )
 
     def set_modification_mapping(
-        self, modification_mapping: Optional[Dict] = None
+        self, modification_mapping: Optional[dict] = None
     ) -> None:
         """Set the modification mapping for the search engine.
 
@@ -149,7 +149,7 @@ class ModificationMapper:
             if isinstance(val, str):
                 self.modification_mapping[mod] = [val]
 
-    def _get_reversed_mod_mapping(self) -> Dict[str, str]:
+    def _get_reversed_mod_mapping(self) -> dict[str, str]:
         """Create a reverse mapping from the modification format used by the search engine to the AlphaBase format."""
         rev_mod_mapping = {}
         for mod_alphabase_format, mod_other_format in self.modification_mapping.items():

--- a/alphabase/psm_reader/msfragger_reader.py
+++ b/alphabase/psm_reader/msfragger_reader.py
@@ -1,7 +1,7 @@
 """MSFragger reader."""
 
 import warnings
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -18,7 +18,7 @@ from alphabase.psm_reader.psm_reader import (
 )
 
 
-def _is_all_fragger_decoy(proteins: List[str]) -> bool:
+def _is_all_fragger_decoy(proteins: list[str]) -> bool:
     """Check if all proteins are MSFragger decoy entries.
 
     Parameters
@@ -37,7 +37,7 @@ def _is_all_fragger_decoy(proteins: List[str]) -> bool:
     )
 
 
-def _extract_position(entry: str) -> Tuple[int, str]:
+def _extract_position(entry: str) -> tuple[int, str]:
     """Extract leading position digits from modification entry.
 
     Parameters
@@ -80,7 +80,7 @@ def _extract_mass_shift(entry: str) -> float:
     )
 
 
-def _parse_lookup_key(lookup_key: str, entry: str) -> Tuple[str, float]:
+def _parse_lookup_key(lookup_key: str, entry: str) -> tuple[str, float]:
     """Parse lookup key into amino acid and mass shift.
 
     Parameters
@@ -111,9 +111,9 @@ class MSFraggerModificationTranslator:
 
     def __init__(
         self,
-        mass_mapped_mods: List[str],
+        mass_mapped_mods: list[str],
         mod_mass_tol: float,
-        rev_mod_mapping: Dict[str, str],
+        rev_mod_mapping: dict[str, str],
     ):
         """Initialize MSFragger modification translator.
 
@@ -161,7 +161,7 @@ class MSFraggerModificationTranslator:
 
         return psm_df
 
-    def _parse_assigned_modifications(self, assigned_mods: str) -> Tuple[str, str]:
+    def _parse_assigned_modifications(self, assigned_mods: str) -> tuple[str, str]:
         """Parse MSFragger Assigned Modifications string.
 
         Parameters
@@ -196,7 +196,7 @@ class MSFraggerModificationTranslator:
             sites
         )
 
-    def _parse_single_modification(self, entry: str) -> Tuple[str, str]:
+    def _parse_single_modification(self, entry: str) -> tuple[str, str]:
         """Parse a single modification entry."""
         if entry.startswith(MsFraggerTokens.N_TERM):
             return self._resolve_terminal_mod(entry, "Any_N-term"), "0"
@@ -287,10 +287,10 @@ class MSFraggerModificationTranslator:
 
 def _get_mods_from_masses(  # noqa: PLR0912, C901 too many branches, too complex TODO: refactor
     sequence: str,
-    msf_aa_mods: List[str],
-    mass_mapped_mods: List[str],
+    msf_aa_mods: list[str],
+    mass_mapped_mods: list[str],
     mod_mass_tol: float,
-) -> Tuple[str, str, str, str]:
+) -> tuple[str, str, str, str]:
     mods = []
     mod_sites = []
     aa_mass_diffs = []

--- a/alphabase/psm_reader/pfind_reader.py
+++ b/alphabase/psm_reader/pfind_reader.py
@@ -1,6 +1,6 @@
 """pFind reader."""
 
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -91,7 +91,7 @@ def translate_pFind_mod(mod_str: str) -> Union[str, NAType]:  # noqa: N802 name 
     return ModificationKeys.SEPARATOR.join(ret_mods)
 
 
-def get_pFind_mods(pfind_mod_str: str) -> Tuple[str, str]:  # noqa: N802 name `get_pFind_mods` should be lowercase TODO: used by peptdeep
+def get_pFind_mods(pfind_mod_str: str) -> tuple[str, str]:  # noqa: N802 name `get_pFind_mods` should be lowercase TODO: used by peptdeep
     """Parse pFind modification string."""
     pfind_mod_str = pfind_mod_str.strip(ModificationKeys.SEPARATOR)
     if not pfind_mod_str:

--- a/alphabase/psm_reader/psm_reader.py
+++ b/alphabase/psm_reader/psm_reader.py
@@ -5,7 +5,7 @@ import io
 import warnings
 from abc import ABC
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Type, Union
+from typing import Optional, Union
 
 import pandas as pd
 
@@ -48,7 +48,7 @@ class PSMReaderBase(ABC):
         fdr: float = 0.01,
         keep_decoy: bool = False,
         rt_unit: Optional[str] = None,
-        mod_seq_columns: Optional[List[str]] = None,
+        mod_seq_columns: Optional[list[str]] = None,
         **kwargs,
     ):
         """The Base class for all PSMReaders.
@@ -182,11 +182,11 @@ class PSMReaderBase(ABC):
         return self._psm_df
 
     @property
-    def modification_mapping(self) -> Dict:
+    def modification_mapping(self) -> dict:
         """Get the modification mapping dictionary."""
         return self._modification_mapper.modification_mapping
 
-    def add_modification_mapping(self, modification_mapping: Dict) -> None:
+    def add_modification_mapping(self, modification_mapping: dict) -> None:
         """Append additional modification mappings for the search engine.
 
         See ModificationMapper.add_modification_mapping for more details.
@@ -194,7 +194,7 @@ class PSMReaderBase(ABC):
         self._modification_mapper.add_modification_mapping(modification_mapping)
 
     def set_modification_mapping(
-        self, modification_mapping: Optional[Dict] = None
+        self, modification_mapping: Optional[dict] = None
     ) -> None:
         """Set the modification mapping for the search engine.
 
@@ -202,17 +202,17 @@ class PSMReaderBase(ABC):
         """
         self._modification_mapper.set_modification_mapping(modification_mapping)
 
-    def add_column_mapping(self, column_mapping: Dict) -> None:
+    def add_column_mapping(self, column_mapping: dict) -> None:
         """Add additional column mappings for the search engine."""
         self.column_mapping = {**self.column_mapping, **column_mapping}
 
-    def load(self, _file: Union[List[str], str]) -> pd.DataFrame:
+    def load(self, _file: Union[list[str], str]) -> pd.DataFrame:
         """Import a single file or multiple files."""
         if isinstance(_file, list):
             return self.import_files(_file)
         return self.import_file(_file)
 
-    def import_files(self, file_list: List[str]) -> pd.DataFrame:
+    def import_files(self, file_list: list[str]) -> pd.DataFrame:
         """Import multiple files."""
         df_list = [self.import_file(file) for file in file_list]
         self._psm_df = pd.concat(df_list, ignore_index=True)
@@ -280,7 +280,7 @@ class PSMReaderBase(ABC):
 
     def _get_actual_column(
         self,
-        column_list: List[str],
+        column_list: list[str],
         df: pd.DataFrame,
     ) -> Optional[str]:
         """Get the first column from `column_list` that is a column of `df`."""
@@ -430,7 +430,7 @@ class PSMReaderBase(ABC):
 
     def filter_psm_by_modifications(
         self,
-        include_mod_set: Optional[Set] = None,
+        include_mod_set: Optional[set] = None,
     ) -> None:
         """Only keeps peptides with modifications in `include_mod_list`."""
         if include_mod_set is None:
@@ -457,7 +457,7 @@ class PSMReaderProvider:
         self.reader_dict = {}
 
     def register_reader(
-        self, reader_type: str, reader_class: Type[PSMReaderBase]
+        self, reader_type: str, reader_class: type[PSMReaderBase]
     ) -> None:
         """Register a reader by reader_type."""
         self.reader_dict[reader_type.lower()] = reader_class

--- a/alphabase/psm_reader/sage_reader.py
+++ b/alphabase/psm_reader/sage_reader.py
@@ -6,7 +6,7 @@ import re
 from abc import ABC
 from collections.abc import Generator
 from functools import partial
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -114,7 +114,7 @@ class SageModificationTranslator:
 
     def _annotate_from_custom_translation(
         self, discovered_modifications_df: pd.DataFrame, translation_df: pd.DataFrame
-    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
         """Annotate modifications from custom translation df, if provided.
 
         Discovered modifications are first matched using the custom translation dataframe.
@@ -237,7 +237,7 @@ def _discover_modifications(psm_df: pd.DataFrame) -> pd.DataFrame:
 
 def _match_modified_sequence(
     sequence: str,
-) -> List[Tuple[str, str, bool, bool, float]]:
+) -> list[tuple[str, str, bool, bool, float]]:
     """Get all matches with the amino acid location.
 
     P[-100.0]EPTIDE -> [('[-100.0]', 'P', False, False, -100.0)]
@@ -334,7 +334,7 @@ def _lookup_modification(
 
 def _translate_modifications(
     sequence: str, mod_translation_df: pd.DataFrame
-) -> Tuple[Optional[str], Optional[str]]:
+) -> tuple[Optional[str], Optional[str]]:
     """Translate modifications in the sequence to alphabase style modifications.
 
     Parameters

--- a/alphabase/psm_reader/sage_reader.py
+++ b/alphabase/psm_reader/sage_reader.py
@@ -4,8 +4,9 @@ import logging
 import multiprocessing as mp
 import re
 from abc import ABC
+from collections.abc import Generator
 from functools import partial
-from typing import Generator, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 import pandas as pd

--- a/alphabase/psm_reader/utils.py
+++ b/alphabase/psm_reader/utils.py
@@ -1,6 +1,6 @@
 """Utility functions for PSM readers."""
 
-from typing import Dict, List, Tuple, Union
+from typing import Union
 
 import pandas as pd
 from pandas._libs.missing import NAType
@@ -19,8 +19,8 @@ for mod_name, unimod_id_ in MOD_DF[["mod_name", "unimod_id"]].to_numpy():
 
 
 def translate_modifications(
-    mod_str: str, mod_dict: Dict
-) -> Tuple[Union[str, NAType], List[str]]:
+    mod_str: str, mod_dict: dict
+) -> tuple[Union[str, NAType], list[str]]:
     """Translate modifications of `mod_str` to the AlphaBase format mapped by mod_dict.
 
     Parameters
@@ -84,7 +84,7 @@ def keep_modifications(mod_str: str, mod_set: set) -> Union[str, NAType]:
     return mod_str
 
 
-def get_extended_modifications(mod_list: List[str]) -> List[str]:
+def get_extended_modifications(mod_list: list[str]) -> list[str]:
     """Get an extended set of modifications from a list of modifications.
 
     Extend bracket types of modifications and strip off underscore, e.g.
@@ -113,7 +113,7 @@ def get_extended_modifications(mod_list: List[str]) -> List[str]:
     return sorted(list(mod_set))
 
 
-def get_column_mapping_for_df(column_mapping: dict, df: pd.DataFrame) -> Dict[str, str]:
+def get_column_mapping_for_df(column_mapping: dict, df: pd.DataFrame) -> dict[str, str]:
     """Determine the mapping of AlphaBase columns to the columns in the given DataFrame.
 
     For each AlphaBase column name, check if the corresponding search engine-specific

--- a/alphabase/smiles/adding_smiles.py
+++ b/alphabase/smiles/adding_smiles.py
@@ -19,7 +19,7 @@ modifications are added or existing ones are changed.
 """
 
 import os
-from typing import Dict, Literal
+from typing import Literal
 
 import pandas as pd
 
@@ -37,8 +37,8 @@ aa_modifier = AminoAcidModifier()
 
 
 def process_modifications(
-    mods_dict: Dict[str, str], mod_type: Literal["ptm", "n_term", "c_term"] = "ptm"
-) -> Dict[str, Dict[str, str]]:
+    mods_dict: dict[str, str], mod_type: Literal["ptm", "n_term", "c_term"] = "ptm"
+) -> dict[str, dict[str, str]]:
     """
     Process various types of modifications (PTM, N-term, C-term) with a unified approach.
 

--- a/alphabase/smiles/smiles.py
+++ b/alphabase/smiles/smiles.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Optional
 
 import pandas as pd
 
@@ -144,7 +144,7 @@ class AminoAcidModifier:
         self._ptm_dict = None
 
     @property
-    def aa_smiles(self) -> Dict[str, str]:
+    def aa_smiles(self) -> dict[str, str]:
         """
         Dictionary of amino acid SMILES.
 
@@ -162,7 +162,7 @@ class AminoAcidModifier:
         return self._aa_smiles
 
     @property
-    def aa_mols(self) -> Dict[str, Chem.Mol]:
+    def aa_mols(self) -> dict[str, Chem.Mol]:
         """
         Dictionary of amino acid RDKit molecules.
 
@@ -178,7 +178,7 @@ class AminoAcidModifier:
         return self._aa_mols
 
     @property
-    def n_term_modifications(self) -> Dict[str, str]:
+    def n_term_modifications(self) -> dict[str, str]:
         """
         Dictionary of N-terminal modifications.
 
@@ -194,7 +194,7 @@ class AminoAcidModifier:
         return self._n_term_modifications
 
     @property
-    def c_term_modifications(self) -> Dict[str, str]:
+    def c_term_modifications(self) -> dict[str, str]:
         """
         Dictionary of C-terminal modifications.
 
@@ -210,7 +210,7 @@ class AminoAcidModifier:
         return self._c_term_modifications
 
     @property
-    def ptm_dict(self) -> Dict[str, str]:
+    def ptm_dict(self) -> dict[str, str]:
         """
         Dictionary of post-translational modifications (PTMs).
 
@@ -228,7 +228,7 @@ class AminoAcidModifier:
             }
         return self._ptm_dict
 
-    def _get_modifications(self, *terms: str) -> Dict[str, str]:
+    def _get_modifications(self, *terms: str) -> dict[str, str]:
         """
         Helper method to get modifications based on specific terms.
 

--- a/alphabase/spectral_library/annotate.py
+++ b/alphabase/spectral_library/annotate.py
@@ -1,6 +1,6 @@
 """Module for annotating spectral libraries with raw mass spectrometry data."""
 
-from typing import List, Tuple, Union
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -329,7 +329,7 @@ def annotate_spectrum(  # noqa: PLR0913
 
 
 def _build_theoretical_flatlib(
-    template: SpecLibFlat, charged_frag_types: List[str]
+    template: SpecLibFlat, charged_frag_types: list[str]
 ) -> SpecLibFlat:
     """Generate a flat spectral library containing theoretical fragments."""
     theoretical_flat = SpecLibFlat(
@@ -360,7 +360,7 @@ def _build_theoretical_flatlib(
 
 
 def add_dense_lib(
-    flatlib: SpecLibFlat, charged_frag_types: Union[List[str], Tuple[str, ...]]
+    flatlib: SpecLibFlat, charged_frag_types: Union[list[str], tuple[str, ...]]
 ) -> SpecLibFlat:
     """Add dense format to the flatlib object.
 

--- a/alphabase/spectral_library/base.py
+++ b/alphabase/spectral_library/base.py
@@ -84,7 +84,7 @@ class SpecLibBase:
         # ['b_z1','b_z2','y_z1','y_modloss_z1', ...];
         # 'b_z1': 'b' is the fragment type and
         # 'z1' is the charge state z=1.
-        charged_frag_types: typing.List[str] = ["b_z1", "b_z2", "y_z1", "y_z2"],
+        charged_frag_types: list[str] = ["b_z1", "b_z2", "y_z1", "y_z2"],
         precursor_mz_min: float = 400,
         precursor_mz_max: float = 6000,
         decoy: str = None,
@@ -194,7 +194,7 @@ class SpecLibBase:
     def append(
         self,
         other: "SpecLibBase",
-        dfs_to_append: typing.List[str] = [
+        dfs_to_append: list[str] = [
             "_precursor_df",
             "_fragment_df",
             "_fragment_intensity_df",

--- a/alphabase/spectral_library/peaks_reader.py
+++ b/alphabase/spectral_library/peaks_reader.py
@@ -7,7 +7,7 @@ alphabase spectral library.
 
 import re
 import warnings
-from typing import List, Optional, Set, Tuple
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -56,7 +56,7 @@ DEFAULT_PEAKS_CHARGED_FRAG_TYPES = [
 
 def _parse_fragment_annotation(
     annotation: str,
-) -> Optional[Tuple[str, int, int, str]]:
+) -> Optional[tuple[str, int, int, str]]:
     """Parse a PEAKS fragment annotation into its components.
 
     Parameters
@@ -88,14 +88,14 @@ class PeaksModificationTranslator:
     precursor for removal.
     """
 
-    def __init__(self, mass_mapped_mods: List[str], mod_mass_tol: float):
+    def __init__(self, mass_mapped_mods: list[str], mod_mass_tol: float):
         """Store the candidate alphabase mod names and the mass tolerance (Da)."""
         self._mass_mapped_mods = mass_mapped_mods
         self._mod_mass_tol = mod_mass_tol
 
     def translate(
         self, sequences: np.ndarray, mod_strings: np.ndarray
-    ) -> Tuple[list, list]:
+    ) -> tuple[list, list]:
         """Translate PEAKS ``Modifications`` cells to alphabase mods and mod_sites.
 
         Parameters
@@ -116,7 +116,7 @@ class PeaksModificationTranslator:
 
         """
         cache = {}
-        unknown_mods: Set[str] = set()
+        unknown_mods: set[str] = set()
         mods_list = []
         sites_list = []
         for sequence, mod_str in zip(sequences, mod_strings):
@@ -138,7 +138,7 @@ class PeaksModificationTranslator:
 
     def _parse_cell(
         self, sequence: str, mod_str: str
-    ) -> Tuple[Optional[str], Optional[str], Set[str]]:
+    ) -> tuple[Optional[str], Optional[str], set[str]]:
         """Parse a single PEAKS ``Modifications`` cell.
 
         Positions are 0-based indices into the backbone sequence; a mod whose name
@@ -166,7 +166,7 @@ class PeaksModificationTranslator:
 
         mods = []
         sites = []
-        unknown: Set[str] = set()
+        unknown: set[str] = set()
         for raw_entry in mod_str.split(";"):
             entry = raw_entry.strip()
             if not entry:
@@ -272,12 +272,12 @@ class PeaksLibraryReader(LibraryReaderBase):
 
     def __init__(  # noqa: PLR0913 many arguments
         self,
-        charged_frag_types: Optional[List[str]] = None,
+        charged_frag_types: Optional[list[str]] = None,
         column_mapping: Optional[dict] = None,
         modification_mapping: Optional[dict] = None,
         fdr: float = 0.01,
         fixed_C57: bool = False,  # noqa: N803, FBT001, FBT002
-        mod_seq_columns: Optional[List[str]] = None,
+        mod_seq_columns: Optional[list[str]] = None,
         rt_unit: Optional[str] = None,
         precursor_mz_min: float = 400,
         precursor_mz_max: float = 2000,

--- a/alphabase/spectral_library/reader.py
+++ b/alphabase/spectral_library/reader.py
@@ -2,7 +2,7 @@
 
 import io
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -24,7 +24,7 @@ class LibraryReaderBase(ModifiedSequenceReader, SpecLibBase):
 
     def __init__(  # noqa: PLR0913 many arguments in function definition
         self,
-        charged_frag_types: List[str] = [
+        charged_frag_types: list[str] = [
             "b_z1",
             "b_z2",
             "y_z1",
@@ -38,7 +38,7 @@ class LibraryReaderBase(ModifiedSequenceReader, SpecLibBase):
         modification_mapping: Optional[dict] = None,
         fdr: float = 0.01,
         fixed_C57: bool = False,  # noqa: FBT001, FBT002, N803 TODO: make this  *,fixed_c57  (breaking)
-        mod_seq_columns: Optional[List[str]] = None,
+        mod_seq_columns: Optional[list[str]] = None,
         rt_unit: Optional[str] = None,
         # library reader-specific:
         precursor_mz_min: float = 400,

--- a/alphabase/spectral_library/translate.py
+++ b/alphabase/spectral_library/translate.py
@@ -1,5 +1,4 @@
 import multiprocessing as mp
-import typing
 
 import numpy as np
 import pandas as pd
@@ -13,7 +12,7 @@ from alphabase.utils import explode_multiple_columns
 
 # @numba.njit #(cannot use numba for pd.Series)
 def create_modified_sequence(
-    seq_mods_sites: typing.Tuple,  # must be ('sequence','mods','mod_sites')
+    seq_mods_sites: tuple,  # must be ('sequence','mods','mod_sites')
     translate_mod_dict: dict = None,
     mod_sep="[]",
     nterm="_",

--- a/alphabase/spectral_library/translate_diann.py
+++ b/alphabase/spectral_library/translate_diann.py
@@ -5,7 +5,7 @@ This reuses shared export helpers from
 preparation for a larger refactor of the library-export code.
 """
 
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import pandas as pd
 import tqdm
@@ -123,7 +123,7 @@ _DIANN_FLAG_FIRST_FRAGMENT = 1 << 4
 
 def _get_first_present_column(
     precursor_df: pd.DataFrame,
-    candidates: List[str],
+    candidates: list[str],
     default: Union[str, float, None] = None,
 ) -> Union[pd.Series, str, float, None]:
     """Return the first present candidate column of `precursor_df`, else `default`."""

--- a/alphabase/spectral_library/validate.py
+++ b/alphabase/spectral_library/validate.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -165,7 +165,7 @@ class Required(Column):
 
 
 class Schema:
-    def __init__(self, name: str, properties: List[Column]):
+    def __init__(self, name: str, properties: list[Column]):
         """
         Schema for validating dataframes
 

--- a/alphabase/tools/data_downloader.py
+++ b/alphabase/tools/data_downloader.py
@@ -204,9 +204,12 @@ class FileDownloader(ABC):
         """
         try:
             if max_size_kb:
-                with urlopen(
-                    self._encoded_url, context=_create_ssl_context()
-                ) as response, open(self._output_path, "wb") as out_file:
+                with (
+                    urlopen(
+                        self._encoded_url, context=_create_ssl_context()
+                    ) as response,
+                    open(self._output_path, "wb") as out_file,
+                ):
                     out_file.write(response.read(max_size_kb * 1024))
                 print(f"Truncating file to max. {max_size_kb} bytes ..")
 
@@ -214,9 +217,12 @@ class FileDownloader(ABC):
                 self._truncate_file(self._output_path)
 
             else:
-                with urlopen(
-                    self._encoded_url, context=_create_ssl_context()
-                ) as response, open(self._output_path, "wb") as out_file:
+                with (
+                    urlopen(
+                        self._encoded_url, context=_create_ssl_context()
+                    ) as response,
+                    open(self._output_path, "wb") as out_file,
+                ):
                     total_size = int(response.headers.get("Content-Length", -1))
                     progress = Progress()
                     block_num = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alphabase"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version", "dependencies", "optional-dependencies"]
 
 authors = [

--- a/tests/unit/io/test_tempmmap.py
+++ b/tests/unit/io/test_tempmmap.py
@@ -114,9 +114,12 @@ def test_create_array_with_custom_temp_dir_not_a_dir():
     """Test creating an array with custom temp dir: not a directory."""
     tempmmap = sys.modules["alphabase.io.tempmmap"]
 
-    with tempfile.TemporaryFile() as temp_file, pytest.raises(
-        ValueError,
-        match=f"The path '{temp_file.name}' does not point to a directory.",
+    with (
+        tempfile.TemporaryFile() as temp_file,
+        pytest.raises(
+            ValueError,
+            match=f"The path '{temp_file.name}' does not point to a directory.",
+        ),
     ):
         # when
         _ = tempmmap.create_empty_mmap(
@@ -223,16 +226,20 @@ def test_create_empty_with_custom_file_path_exists():
     tempmmap = sys.modules["alphabase.io.tempmmap"]
 
     # when
-    with tempfile.TemporaryFile() as temp_file, pytest.raises(
-        ValueError,
-        match=f"The file '{temp_file.name}' already exists. Set overwrite to True to overwrite the file or choose a different name.",
+    with (
+        tempfile.TemporaryFile() as temp_file,
+        pytest.raises(
+            ValueError,
+            match=f"The file '{temp_file.name}' already exists. Set overwrite to True to overwrite the file or choose a different name.",
+        ),
     ):
         _ = tempmmap.create_empty_mmap((5, 5), np.float32, file_path=temp_file.name)
 
     # when 2
-    with tempfile.TemporaryDirectory() as temp_dir, open(
-        f"{temp_dir}/temp_mmap.hdf", "w"
-    ) as temp_file:
+    with (
+        tempfile.TemporaryDirectory() as temp_dir,
+        open(f"{temp_dir}/temp_mmap.hdf", "w") as temp_file,
+    ):
         _ = tempmmap.create_empty_mmap(
             (5, 5), np.float32, file_path=temp_file.name, overwrite=True
         )

--- a/tests/unit/pg_reader/test_alphadia_reader.py
+++ b/tests/unit/pg_reader/test_alphadia_reader.py
@@ -1,8 +1,9 @@
 """Unit tests for AlphaDia PG reader."""
 
 import os
+from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pandas as pd

--- a/tests/unit/pg_reader/test_pg_reader.py
+++ b/tests/unit/pg_reader/test_pg_reader.py
@@ -1,7 +1,8 @@
 """Unit tests for PGReaderBase class."""
 
 import os
-from typing import Any, Generator, Union
+from collections.abc import Generator
+from typing import Any, Union
 from unittest.mock import Mock, patch
 
 import pandas as pd


### PR DESCRIPTION
Drop support for python 3.8, requires reformatting and relinting. Done in pair with @lucas-diedrich 

supersedes https://github.com/MannLabs/alphabase/pull/439 and https://github.com/MannLabs/alphabase/pull/431